### PR TITLE
feat: implement configurable path trailing slash policy

### DIFF
--- a/aeronet/http/include/aeronet/http-request.hpp
+++ b/aeronet/http/include/aeronet/http-request.hpp
@@ -10,6 +10,7 @@ using HttpHeaders = flat_hash_map<std::string_view, std::string_view>;
 
 struct HttpRequest {
   [[nodiscard]] std::string_view findHeader(std::string_view key) const;
+  [[nodiscard]] bool wantClose() const;
 
   std::string_view method;
   std::string_view target;

--- a/aeronet/http/include/aeronet/http-response.hpp
+++ b/aeronet/http/include/aeronet/http-response.hpp
@@ -1,16 +1,140 @@
 #pragma once
 
+#include <cassert>
+#include <cstdint>
+#include <ranges>
 #include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
 
+#include "flat-hash-map.hpp"
+#include "http-constants.hpp"
 #include "http-status-code.hpp"
 
 namespace aeronet {
 
-struct HttpResponse {
-  http::StatusCode statusCode{200};
-  std::string reason{"OK"};
-  std::string body{"Hello from aeronet"};
-  std::string contentType{"text/plain"};
+class HttpResponse {
+ public:
+  using HeadersMap = flat_hash_map<std::string, std::string, std::hash<std::string_view>, std::equal_to<>>;
+
+  // Creates a response with given status code.
+  // Usage: HttpResponse(200).reason("OK").body("hello").contentType("text/plain");
+  explicit HttpResponse(http::StatusCode code = 200) noexcept : _statusCode(code) {
+    assert(_statusCode >= 100 && _statusCode < 1000);
+  }
+
+  HttpResponse& statusCode(http::StatusCode statusCode) {
+    assert(statusCode >= 100 && statusCode < 1000);
+    _statusCode = statusCode;
+    return *this;
+  }
+
+  [[nodiscard]] http::StatusCode statusCode() const { return _statusCode; }
+
+  // Fluent setters (in-place) accepting string-like or contiguous char ranges.
+  template <class S>
+    requires((std::is_convertible_v<S, std::string_view>) ||
+             (std::ranges::contiguous_range<S> &&
+              std::same_as<std::remove_cvref_t<std::ranges::range_value_t<S>>, char>))
+  HttpResponse& reason(S&& src) {
+    assignTo(_reason, std::forward<S>(src));
+    return *this;
+  }
+
+  [[nodiscard]] std::string_view reason() const { return _reason; }
+
+  template <class S>
+    requires((std::is_convertible_v<S, std::string_view>) ||
+             (std::ranges::contiguous_range<S> &&
+              std::same_as<std::remove_cvref_t<std::ranges::range_value_t<S>>, char>))
+  HttpResponse& body(S&& src) {
+    assignTo(_body, std::forward<S>(src));
+    return *this;
+  }
+
+  [[nodiscard]] std::string_view body() const { return _body; }
+
+  template <class S>
+    requires((std::is_convertible_v<S, std::string_view>) ||
+             (std::ranges::contiguous_range<S> &&
+              std::same_as<std::remove_cvref_t<std::ranges::range_value_t<S>>, char>))
+  HttpResponse& contentType(S&& src) {
+    return header(http::ContentType, std::forward<S>(src));
+  }
+  template <class S>
+    requires((std::is_convertible_v<S, std::string_view>) ||
+             (std::ranges::contiguous_range<S> &&
+              std::same_as<std::remove_cvref_t<std::ranges::range_value_t<S>>, char>))
+  HttpResponse& location(S&& src) {
+    return header(http::Location, std::forward<S>(src));
+  }
+
+  // Use this method to insert a new custom header.
+  // Do not insert any reserved header (for which IsReservedHeader is true), doing so is undefined behavior.
+  template <class S1, class S2>
+    requires(std::is_convertible_v<S1, std::string_view>) &&
+            (std::is_convertible_v<S2, std::string_view> ||
+             (std::ranges::contiguous_range<S2> &&
+              std::same_as<std::remove_cvref_t<std::ranges::range_value_t<S2>>, char>))
+  HttpResponse& header(S1&& key, S2&& value) {
+    assert(!IsReservedHeader(key));
+    auto [it, inserted] = _headers.emplace(std::forward<S1>(key), std::forward<S2>(value));
+    using HdrLenT = decltype(_headersKVLength);
+    if (inserted) {
+      _headersKVLength += static_cast<HdrLenT>(it->first.size()) + static_cast<HdrLenT>(it->second.size());
+    } else {
+      auto oldHeaderLen = static_cast<HdrLenT>(it->first.size()) + static_cast<HdrLenT>(it->second.size());
+      it->second = std::forward<S2>(value);
+      _headersKVLength +=
+          static_cast<HdrLenT>(it->first.size()) + static_cast<HdrLenT>(it->second.size()) - oldHeaderLen;
+    }
+    return *this;
+  }
+
+  [[nodiscard]] const HeadersMap& headers() const { return _headers; }
+
+  [[nodiscard]] std::size_t headersTotalLen() const {
+    return static_cast<std::size_t>(_headersKVLength) +
+           ((http::CRLF.size() + http::HeaderSep.size()) * _headers.size());
+  }
+
+  // Centralized rule for headers the user may not set directly (normal or streaming path).
+  // These are either automatically emitted (Date, Content-Length, Connection, Transfer-Encoding) or
+  // would create ambiguous / unsupported semantics if user-supplied before dedicated feature support
+  // (Trailer, Upgrade, TE). Keeping this here allows future optimization of storage layout without
+  // scattering the logic.
+  // You can use 'static_assert' to make sure at compilation time that the header you are about to insert is not
+  // reserved. The list of reserved headers is unlikely to change in the future, but they are mostly technical /
+  // framework headers that aeronet manages internally and probably not very interesting for the client.
+  // Example:
+  //     static_assert(!aeronet::HttpResponse::IsReservedHeader("X-My-Header")); // OK
+  //     static_assert(!aeronet::HttpResponse::IsReservedHeader("Content-Length")); // Not OK
+  [[nodiscard]] static constexpr bool IsReservedHeader(std::string_view name) noexcept {
+    using namespace http;
+    return name == Connection || name == Date || name == ContentLength || name == TransferEncoding || name == Trailer ||
+           name == Upgrade || name == TE;
+  }
+
+ private:
+  friend class HttpServer;
+
+  template <class S2>
+  static void assignTo(std::string& dest, S2&& source) {
+    if constexpr (std::is_same_v<std::remove_cvref_t<S2>, std::string> && std::is_rvalue_reference_v<S2&&>) {
+      dest = std::forward<S2>(source);
+    } else if constexpr (std::is_convertible_v<S2, std::string_view>) {
+      dest.assign(std::string_view(source));
+    } else {
+      dest.assign(std::ranges::data(source), std::ranges::size(source));
+    }
+  }
+
+  http::StatusCode _statusCode;
+  uint32_t _headersKVLength{};
+  std::string _reason;
+  HeadersMap _headers;
+  std::string _body;
 };
 
 }  // namespace aeronet

--- a/aeronet/http/include/http-constants.hpp
+++ b/aeronet/http/include/http-constants.hpp
@@ -30,10 +30,16 @@ inline constexpr std::string_view DELETE = "DELETE";
 inline constexpr std::string_view Connection = "Connection";
 inline constexpr std::string_view ContentLength = "Content-Length";
 inline constexpr std::string_view TransferEncoding = "Transfer-Encoding";
+inline constexpr std::string_view TE = "TE";
+inline constexpr std::string_view Trailer = "Trailer";
+inline constexpr std::string_view Upgrade = "Upgrade";
 inline constexpr std::string_view Expect = "Expect";
 inline constexpr std::string_view Host = "Host";
 inline constexpr std::string_view Date = "Date";  // only used for writing (server side)
 inline constexpr std::string_view ContentType = "Content-Type";
+inline constexpr std::string_view Location = "Location";
+
+inline constexpr std::string_view HeaderSep = ": ";
 
 // Common Header Values (lowercase tokens where case-insensitive comparison used)
 inline constexpr std::string_view keepalive = "keep-alive";
@@ -45,6 +51,7 @@ inline constexpr std::string_view h100_continue = "100-continue";  // value of E
 inline constexpr std::string_view HTTP11_100_CONTINUE = "HTTP/1.1 100 Continue\r\n\r\n";
 
 // Reason Phrases (only those we currently emit explicitly)
+inline constexpr std::string_view MovedPermanently = "Moved Permanently";                        // 301
 inline constexpr std::string_view ReasonBadRequest = "Bad Request";                              // 400
 inline constexpr std::string_view ReasonMethodNotAllowed = "Method Not Allowed";                 // 405
 inline constexpr std::string_view ReasonPayloadTooLarge = "Payload Too Large";                   // 413
@@ -53,13 +60,19 @@ inline constexpr std::string_view ReasonInternalServerError = "Internal Server E
 inline constexpr std::string_view ReasonNotImplemented = "Not Implemented";                      // 501
 inline constexpr std::string_view ReasonHTTPVersionNotSupported = "HTTP Version Not Supported";  // 505
 
+// Content type
+inline constexpr std::string_view ContentTypeTextPlain = "text/plain";
+
 inline constexpr std::string_view CRLF = "\r\n";
+inline constexpr std::string_view DoubleCRLF = "\r\n\r\n";
 
 // Return the canonical reason phrase for a subset of status codes we care about.
 // If an unmapped status is provided, returns an empty string_view, letting callers
 // decide whether to supply a custom phrase.
 constexpr std::string_view reasonPhraseFor(http::StatusCode status) noexcept {
   switch (status) {
+    case 301:
+      return MovedPermanently;
     case 400:
       return ReasonBadRequest;
     case 405:

--- a/aeronet/http/include/http-error-build.hpp
+++ b/aeronet/http/include/http-error-build.hpp
@@ -10,6 +10,6 @@
 
 namespace aeronet {
 
-RawChars BuildSimpleError(http::StatusCode status, std::string_view reason, std::string_view date, bool closeConn);
+RawChars BuildSimpleError(http::StatusCode status, std::string_view date, bool closeConn);
 
 }  // namespace aeronet

--- a/aeronet/http/include/http-response-build.hpp
+++ b/aeronet/http/include/http-response-build.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <string_view>
 
 #include "aeronet/http-response.hpp"
@@ -12,7 +11,6 @@ namespace aeronet::http {
 // bodySize allows specifying the length that would be sent (e.g. for HEAD requests
 // where the body itself is not transmitted). The date must be a preformatted RFC 7231
 // timestamp string. keepAlive controls the Connection header value.
-RawChars buildHead(const HttpResponse &resp, std::string_view httpVersion, std::string_view date, bool keepAlive,
-                   std::size_t bodySize);
+RawChars buildHead(HttpResponse &resp, std::string_view httpVersion, std::string_view date, bool keepAlive);
 
 }  // namespace aeronet::http

--- a/aeronet/http/src/http-error-build.cpp
+++ b/aeronet/http/src/http-error-build.cpp
@@ -9,13 +9,9 @@
 
 namespace aeronet {
 
-RawChars BuildSimpleError(http::StatusCode status, std::string_view reason, std::string_view date, bool closeConn) {
-  // If caller passed empty reason, try to supply a canonical one.
-  if (reason.empty()) {
-    if (auto mapped = http::reasonPhraseFor(status); !mapped.empty()) {
-      reason = mapped;
-    }
-  }
+RawChars BuildSimpleError(http::StatusCode status, std::string_view date, bool closeConn) {
+  std::string_view reason = http::reasonPhraseFor(status);
+
   static constexpr std::string_view kSep = ": ";
   static constexpr std::string_view kEnd = "\r\n\r\n";
 

--- a/aeronet/http/src/http-request.cpp
+++ b/aeronet/http/src/http-request.cpp
@@ -2,8 +2,9 @@
 
 #include <string_view>
 
+#include "http-constants.hpp"
 #include "string-equal-ignore-case.hpp"
-
+#include "toupperlower.hpp"
 namespace aeronet {
 
 std::string_view HttpRequest::findHeader(std::string_view key) const {
@@ -17,6 +18,21 @@ std::string_view HttpRequest::findHeader(std::string_view key) const {
     }
   }
   return {};
+}
+
+[[nodiscard]] bool HttpRequest::wantClose() const {
+  std::string_view connVal = findHeader(http::Connection);
+  if (connVal.size() == http::close.size()) {
+    for (std::size_t iChar = 0; iChar < http::close.size(); ++iChar) {
+      const char lhs = tolower(connVal[iChar]);
+      const char rhs = static_cast<char>(http::close[iChar]);
+      if (lhs != rhs) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
 }
 
 }  // namespace aeronet

--- a/aeronet/http/src/http-response.cpp
+++ b/aeronet/http/src/http-response.cpp
@@ -1,52 +1,69 @@
 #include "aeronet/http-response.hpp"
 
+#include <cassert>
 #include <cstddef>
 #include <string_view>
 
 #include "http-constants.hpp"
 #include "http-response-build.hpp"
-#include "nchars.hpp"
 #include "raw-chars.hpp"
 #include "stringconv.hpp"
 
 namespace aeronet::http {
 
-RawChars buildHead(const HttpResponse &resp, std::string_view httpVersion, std::string_view date, bool keepAlive,
-                   std::size_t bodySize) {
-  static constexpr std::string_view kSep = ": ";
-  static constexpr std::string_view kEnd = "\r\n\r\n";
-
+RawChars buildHead(HttpResponse &resp, std::string_view httpVersion, std::string_view date, bool keepAlive) {
   std::string_view keepAliveStr = keepAlive ? http::keepalive : http::close;
 
-  RawChars header(httpVersion.size() + 2U + static_cast<std::size_t>(nchars(resp.statusCode)) + resp.reason.size() +
-                  (4U * http::CRLF.size()) + http::Date.size() + (4U * kSep.size()) + date.size() +
-                  http::ContentType.size() + resp.contentType.size() + http::ContentLength.size() +
-                  static_cast<std::size_t>(nchars(bodySize)) + http::Connection.size() + keepAliveStr.size() +
-                  kEnd.size());
+  auto bodySize = resp.body().size();
+
+  // Base headers: Date, Content-Type, Content-Length, Connection (+ optional Location)
+  // Compute size conservatively: base + headers
+  const std::size_t size = httpVersion.size() + 2U + 3U + resp.reason().size() +
+                           // CRLF after status line
+                           http::CRLF.size() +
+                           // Custom headers
+                           resp.headersTotalLen() +
+                           // Date header
+                           http::Date.size() + http::HeaderSep.size() + date.size() + http::CRLF.size() +
+                           // Content-Length
+                           http::ContentLength.size() + http::HeaderSep.size() +
+                           static_cast<std::size_t>(nchars(bodySize)) + http::CRLF.size() +
+                           // Connection
+                           http::Connection.size() + http::HeaderSep.size() + keepAliveStr.size() +
+                           http::DoubleCRLF.size();
+
+  RawChars header(size);
 
   // Trust caller to validate version (only HTTP/1.0 or HTTP/1.1 allowed upstream)
   header.unchecked_append(httpVersion);
   header.unchecked_push_back(' ');
-  header.unchecked_append(std::string_view(IntegralToCharVector(resp.statusCode)));
+  header.unchecked_append(std::string_view(IntegralToCharVector(resp.statusCode())));
   header.unchecked_push_back(' ');
-  header.unchecked_append(resp.reason);
+  header.unchecked_append(resp.reason());
   header.unchecked_append(http::CRLF);
+  // Custom headers
+  for (const auto &[name, value] : resp.headers()) {
+    header.unchecked_append(name);
+    header.unchecked_append(http::HeaderSep);
+    header.unchecked_append(value);
+    header.unchecked_append(http::CRLF);
+  }
+  // Date
   header.unchecked_append(http::Date);
-  header.unchecked_append(kSep);
+  header.unchecked_append(http::HeaderSep);
   header.unchecked_append(date);
   header.unchecked_append(http::CRLF);
-  header.unchecked_append(http::ContentType);
-  header.unchecked_append(kSep);
-  header.unchecked_append(resp.contentType);
-  header.unchecked_append(http::CRLF);
+  // Content-Length
   header.unchecked_append(http::ContentLength);
-  header.unchecked_append(kSep);
+  header.unchecked_append(http::HeaderSep);
   header.unchecked_append(std::string_view(IntegralToCharVector(bodySize)));
   header.unchecked_append(http::CRLF);
+  // Connection
   header.unchecked_append(http::Connection);
-  header.unchecked_append(kSep);
+  header.unchecked_append(http::HeaderSep);
   header.unchecked_append(keepAliveStr);
-  header.unchecked_append(kEnd);
+  header.unchecked_append(http::DoubleCRLF);
+  assert(header.size() == size);
   return header;
 }
 

--- a/aeronet/main/include/aeronet/async-http-server.hpp
+++ b/aeronet/main/include/aeronet/async-http-server.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
 #include <exception>
-#include <functional>
-#include <stdexcept>
 #include <thread>
+#include <utility>
 
 #include "aeronet/http-server.hpp"
 

--- a/aeronet/main/include/aeronet/http-response-writer.hpp
+++ b/aeronet/main/include/aeronet/http-response-writer.hpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "flat-hash-map.hpp"
+#include "http-constants.hpp"
 #include "http-status-code.hpp"
 
 namespace aeronet {
@@ -15,15 +16,15 @@ class HttpServer;  // fwd
 
 class HttpResponseWriter {
  public:
-  HttpResponseWriter(HttpServer& srv, int fd, bool headRequest);
+  HttpResponseWriter(HttpServer& srv, int fd, bool headRequest, bool requestConnClose);
 
-  void setStatus(http::StatusCode code, std::string reason = {});
+  void statusCode(http::StatusCode code, std::string reason = {});
 
-  void setHeader(std::string name, std::string value);
+  void header(std::string name, std::string value);
 
-  void setContentType(std::string ct) { setHeader("Content-Type", std::move(ct)); }
+  void contentType(std::string ct) { header(std::string(http::ContentType), std::move(ct)); }
 
-  void setContentLength(std::size_t len);
+  void contentLength(std::size_t len);
 
   // Backpressure-aware write. Returns true if accepted (queued or immediately written). Returns
   // false if a fatal error occurred or the server marked the connection for closure / overflow.
@@ -45,6 +46,7 @@ class HttpResponseWriter {
   bool _chunked{true};
   bool _ended{false};
   bool _failed{false};
+  bool _requestConnClose{false};
   http::StatusCode _statusCode{200};
   std::string _reason{"OK"};
   flat_hash_map<std::string, std::string, std::hash<std::string_view>, std::equal_to<>> _headers;

--- a/benchmarks/e2e/bench_throughput_local.cpp
+++ b/benchmarks/e2e/bench_throughput_local.cpp
@@ -11,7 +11,7 @@ void BenchThroughputSkeleton(benchmark::State& state) {
   aeronet::HttpServer server(aeronet::HttpServerConfig{}.withPort(0));
   server.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse resp;
-    resp.body = "OK";
+    resp.body("OK");
     return resp;
   });
   for (auto it : state) {

--- a/benchmarks/frameworks/bench_frameworks_basic.cpp
+++ b/benchmarks/frameworks/bench_frameworks_basic.cpp
@@ -73,7 +73,7 @@ struct AeronetServerRunner {
     async.server().setHandler([](const aeronet::HttpRequest &req) {
       aeronet::HttpResponse resp;
       auto sizeOpt = parseSizeParam(req.target);
-      resp.body = makeIota(sizeOpt.value_or(0));
+      resp.body(makeIota(sizeOpt.value_or(0)));
       return resp;
     });
     async.start();

--- a/benchmarks/internal/bench_http_roundtrip.cpp
+++ b/benchmarks/internal/bench_http_roundtrip.cpp
@@ -7,15 +7,15 @@
 namespace {
 class BasicRoundTrip : public benchmark::Fixture {
  protected:
-  void SetUp(const benchmark::State&) override {
+  void SetUp([[maybe_unused]] const benchmark::State& state) override {
     server_ = std::make_unique<aeronet::HttpServer>(aeronet::HttpServerConfig{}.withPort(0));
     server_->setHandler([](const aeronet::HttpRequest&) {
-      aeronet::HttpResponse r;
-      r.body = "OK";
-      return r;
+      aeronet::HttpResponse resp;
+      resp.body("OK");
+      return resp;
     });
   }
-  void TearDown(const benchmark::State&) override { server_.reset(); }
+  void TearDown([[maybe_unused]] const benchmark::State& state) override { server_.reset(); }
   std::unique_ptr<aeronet::HttpServer> server_;
 };
 

--- a/benchmarks/internal/bench_request_parse.cpp
+++ b/benchmarks/internal/bench_request_parse.cpp
@@ -22,7 +22,7 @@ class MinimalServerFixture : public benchmark::Fixture {
     server = std::make_unique<aeronet::HttpServer>(aeronet::HttpServerConfig{}.withPort(0));
     server->setHandler([](const aeronet::HttpRequest&) {
       aeronet::HttpResponse resp;
-      resp.body = "OK";
+      resp.body("OK");
       return resp;
     });
     loopThread =
@@ -42,6 +42,7 @@ class MinimalServerFixture : public benchmark::Fixture {
 };
 
 bool sendGet(uint16_t port) {
+  // TODO: use ClientConnection from test_util.hpp
   int fd = ::socket(AF_INET, SOCK_STREAM, 0);
   if (fd < 0) {
     return false;

--- a/examples/async.cpp
+++ b/examples/async.cpp
@@ -1,4 +1,5 @@
 #include <aeronet/async-http-server.hpp>
+#include <aeronet/http-response.hpp>
 #include <aeronet/http-server-config.hpp>
 #include <aeronet/http-server.hpp>
 #include <chrono>
@@ -12,10 +13,7 @@ int main() {
   cfg.withPort(0);
   HttpServer server(cfg);
   server.setHandler([](const HttpRequest&) {
-    HttpResponse resp{200, "OK"};
-    resp.contentType = "text/plain";
-    resp.body = "hello from async server\n";
-    return resp;
+    return HttpResponse(200).reason("OK").contentType(http::ContentTypeTextPlain).body("hello from async server\n");
   });
 
   AsyncHttpServer async(std::move(server));

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -24,13 +24,16 @@ int main(int argc, char **argv) {
   aeronet::HttpServer server(aeronet::HttpServerConfig{}.withPort(port));
   server.setHandler([](const aeronet::HttpRequest &req) {
     aeronet::HttpResponse resp;
-    resp.body = std::string("Hello from aeronet minimal server! You requested ") + std::string(req.target) + '\n';
-    resp.body += "Method: " + std::string(req.method) + "\n";
-    resp.body += "Version: " + std::string(req.version) + "\n";
-    resp.body += "Headers:\n";
+    std::string body("Hello from aeronet minimal server! You requested ");
+    body += req.target;
+    body.push_back('\n');
+    body += "Method: " + std::string(req.method) + "\n";
+    body += "Version: " + std::string(req.version) + "\n";
+    body += "Headers:\n";
     for (const auto &[headerKey, headerValue] : req.headers) {
-      resp.body += std::string(headerKey) + ": " + std::string(headerValue) + "\n";
+      body += std::string(headerKey) + ": " + std::string(headerValue) + "\n";
     }
+    resp.body(std::move(body));
     return resp;
   });
 

--- a/examples/multi.cpp
+++ b/examples/multi.cpp
@@ -10,6 +10,7 @@
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/multi-http-server.hpp"
+#include "http-constants.hpp"
 #include "log.hpp"
 
 namespace {
@@ -31,12 +32,10 @@ int main(int argc, char** argv) {
   cfg.withPort(port).withReusePort(true);
   aeronet::MultiHttpServer multi(cfg, static_cast<uint32_t>(threads));
   multi.setHandler([](const aeronet::HttpRequest& req) {
-    aeronet::HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.contentType = "text/plain";
-    resp.body = std::string("multi reactor response ") + std::string(req.target);
-    return resp;
+    return aeronet::HttpResponse(200)
+        .reason("OK")
+        .contentType(aeronet::http::ContentTypeTextPlain)
+        .body(std::string("multi reactor response ") + std::string(req.target));
   });
   multi.start();
   aeronet::log::info("Listening on {} with {} reactors (SO_REUSEPORT). Press Ctrl+C to stop.", multi.port(), threads);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,10 @@ aeronet_http_test(http_routing http_routing.cpp)
 
 aeronet_http_test(http_server_move http_server_move.cpp)
 
+# Trailing slash policy tests
+aeronet_http_test(http_trailing_slash http_trailing_slash.cpp)
+aeronet_http_test(http_headers_custom http_headers_custom.cpp)
+
 # Stats exposure test
 aeronet_http_test(http_stats http_stats.cpp)
 aeronet_http_test(server_stats_json server_stats_json.cpp)
@@ -120,6 +124,8 @@ set(REGISTERED_TEST_SOURCES_REL
 	http_url_decoding.cpp
 	multi_http_server_convenience_constructors.cpp
 	multi_http_server_auto.cpp
+	http_trailing_slash.cpp
+	http_headers_custom.cpp
 	test_version.cpp
 	# TLS tests are intentionally omitted from the always-present list because they are
 	# guarded by AERONET_ENABLE_OPENSSL. If OpenSSL is enabled but these files are removed

--- a/tests/http_10.cpp
+++ b/tests/http_10.cpp
@@ -30,7 +30,7 @@ TEST(Http10, BasicVersionEcho) {
   TestServer ts(aeronet::HttpServerConfig{});
   ts.server.setHandler([]([[maybe_unused]] const aeronet::HttpRequest& req) {
     aeronet::HttpResponse respObj;
-    respObj.body = "A";
+    respObj.body("A");
     return respObj;
   });
   std::string req = "GET /x HTTP/1.0\r\nHost: h\r\n\r\n";
@@ -42,7 +42,7 @@ TEST(Http10, No100ContinueEvenIfHeaderPresent) {
   TestServer ts(aeronet::HttpServerConfig{});
   ts.server.setHandler([]([[maybe_unused]] const aeronet::HttpRequest& req) {
     aeronet::HttpResponse respObj;
-    respObj.body = "B";
+    respObj.body("B");
     return respObj;
   });
   // Expect ignored in HTTP/1.0
@@ -57,7 +57,7 @@ TEST(Http10, RejectTransferEncoding) {
   TestServer ts(aeronet::HttpServerConfig{});
   ts.server.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse respObj;
-    respObj.body = "C";
+    respObj.body("C");
     return respObj;
   });
   std::string req = "GET /te HTTP/1.0\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n";
@@ -70,7 +70,7 @@ TEST(Http10, KeepAliveOptInStillWorks) {
   TestServer ts(aeronet::HttpServerConfig{});
   ts.server.setHandler([]([[maybe_unused]] const aeronet::HttpRequest& req) {
     aeronet::HttpResponse respObj;
-    respObj.body = "D";
+    respObj.body("D");
     return respObj;
   });
   ClientConnection clientConnection(ts.port());

--- a/tests/http_additional.cpp
+++ b/tests/http_additional.cpp
@@ -20,7 +20,7 @@ TEST(HttpPipeline, TwoRequestsBackToBack) {
   TestServer ts(aeronet::HttpServerConfig{});
   ts.server.setHandler([](const aeronet::HttpRequest& req) {
     aeronet::HttpResponse respObj;
-    respObj.body = std::string("E:") + std::string(req.target);
+    respObj.body(std::string("E:") + std::string(req.target));
     return respObj;
   });
   ClientConnection clientConnection(ts.port());
@@ -39,7 +39,7 @@ TEST(HttpExpect, ZeroLengthNo100) {
   TestServer ts(aeronet::HttpServerConfig{});
   ts.server.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse respObj;
-    respObj.body = "Z";
+    respObj.body("Z");
     return respObj;
   });
   ClientConnection clientConnection(ts.port());
@@ -58,7 +58,7 @@ TEST(HttpMaxRequests, CloseAfterLimit) {
   TestServer ts(cfg);
   ts.server.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse respObj;
-    respObj.body = "Q";
+    respObj.body("Q");
     return respObj;
   });
   ClientConnection clientConnection(ts.port());
@@ -76,7 +76,7 @@ TEST(HttpPipeline, SecondMalformedAfterSuccess) {
   TestServer ts(aeronet::HttpServerConfig{});
   ts.server.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse respObj;
-    respObj.body = "OK";
+    respObj.body("OK");
     return respObj;
   });
   ClientConnection clientConnection(ts.port());
@@ -94,7 +94,7 @@ TEST(HttpContentLength, ExplicitTooLarge413) {
   TestServer ts(cfg);
   ts.server.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse respObj;
-    respObj.body = "R";
+    respObj.body("R");
     return respObj;
   });
   ClientConnection clientConnection(ts.port());

--- a/tests/http_basic.cpp
+++ b/tests/http_basic.cpp
@@ -29,11 +29,13 @@ TEST(HttpBasic, SimpleGet) {
   ts.server.setHandler([](const aeronet::HttpRequest& req) {
     aeronet::HttpResponse resp;
     auto testHeaderIt = req.headers.find("X-Test");
-    resp.body = std::string("You requested: ") + std::string(req.target);
+    std::string body("You requested: ");
+    body += req.target;
     if (testHeaderIt != req.headers.end() && !testHeaderIt->second.empty()) {
-      resp.body += ", X-Test=";
-      resp.body.append(testHeaderIt->second);
+      body += ", X-Test=";
+      body.append(testHeaderIt->second);
     }
+    resp.body(std::move(body));
     return resp;
   });
   std::string resp = httpGet(ts.port(), "/abc");

--- a/tests/http_date.cpp
+++ b/tests/http_date.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
-#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <regex>
@@ -44,7 +43,7 @@ TEST(HttpDate, PresentAndFormat) {
   std::atomic_bool stop{false};
   aeronet::HttpServer server(aeronet::HttpServerConfig{});
   auto port = server.port();
-  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse{}; });
+  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse(200); });
   std::jthread th([&] { server.runUntil([&] { return stop.load(); }); });
   std::this_thread::sleep_for(100ms);
   auto resp = rawGet(port);
@@ -60,7 +59,7 @@ TEST(HttpDate, StableWithinSameSecond) {
   std::atomic_bool stop{false};
   aeronet::HttpServer server(aeronet::HttpServerConfig{});
   auto port = server.port();
-  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse{}; });
+  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse(200); });
   std::jthread th([&] { server.runUntil([&] { return stop.load(); }); });
   std::this_thread::sleep_for(30ms);
 
@@ -115,7 +114,7 @@ TEST(HttpDate, ChangesAcrossSecondBoundary) {
   std::atomic_bool stop{false};
   aeronet::HttpServer server(aeronet::HttpServerConfig{});
   auto port = server.port();
-  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse{}; });
+  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse(200); });
   std::jthread th([&] { server.runUntil([&] { return stop.load(); }); });
   std::this_thread::sleep_for(50ms);
   auto first = rawGet(port);

--- a/tests/http_errors.cpp
+++ b/tests/http_errors.cpp
@@ -37,7 +37,7 @@ class HttpErrorParamTest : public ::testing::TestWithParam<ErrorCase> {};
 
 TEST_P(HttpErrorParamTest, EmitsExpectedStatus) {
   TestServer ts(aeronet::HttpServerConfig{});
-  ts.server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse{}; });
+  ts.server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse(200); });
   const auto& param = GetParam();
   std::string resp = sendAndCollect(ts.port(), param.request);
   ASSERT_NE(std::string::npos, resp.find(param.expectedStatus)) << "Case=" << param.name << "\nResp=" << resp;
@@ -58,11 +58,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST(HttpKeepAlive10, DefaultCloseWithoutHeader) {
   TestServer ts(aeronet::HttpServerConfig{});
   auto port = ts.port();
-  ts.server.setHandler([](const aeronet::HttpRequest&) {
-    aeronet::HttpResponse response;
-    response.body = "ok";
-    return response;
-  });
+  ts.server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("ok"); });
   // HTTP/1.0 without Connection: keep-alive should close
   ClientConnection clientConnection(port);
   int fd = clientConnection.fd();
@@ -88,11 +84,7 @@ TEST(HttpKeepAlive10, DefaultCloseWithoutHeader) {
 TEST(HttpKeepAlive10, OptInWithHeader) {
   TestServer ts(aeronet::HttpServerConfig{});
   auto port = ts.port();
-  ts.server.setHandler([](const aeronet::HttpRequest&) {
-    aeronet::HttpResponse response;
-    response.body = "ok";
-    return response;
-  });
+  ts.server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("ok"); });
   ClientConnection clientConnection(port);
   int fd = clientConnection.fd();
   ASSERT_GE(fd, 0);

--- a/tests/http_head_maxrequests.cpp
+++ b/tests/http_head_maxrequests.cpp
@@ -18,7 +18,7 @@ TEST(HttpHead, MaxRequestsApplied) {
   auto port = server.port();
   server.setHandler([]([[maybe_unused]] const aeronet::HttpRequest& req) {
     aeronet::HttpResponse resp;
-    resp.body = "IGNORED";
+    resp.body("IGNORED");
     return resp;
   });
   std::jthread th([&] { server.run(); });

--- a/tests/http_header_timeout.cpp
+++ b/tests/http_header_timeout.cpp
@@ -13,6 +13,7 @@
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/http-server.hpp"
+#include "http-constants.hpp"
 #include "socket.hpp"
 #include "test_server_fixture.hpp"
 
@@ -39,10 +40,7 @@ TEST(HttpHeaderTimeout, SlowHeadersConnectionClosed) {
   cfg.withPort(0).withHeaderReadTimeout(std::chrono::milliseconds(50));
   TestServer ts(cfg);
   ts.server.setHandler([](const HttpRequest&) {
-    HttpResponse resp{200, "OK"};
-    resp.body = "hi";
-    resp.contentType = "text/plain";
-    return resp;
+    return aeronet::HttpResponse(200).reason("OK").body("hi").contentType(aeronet::http::ContentTypeTextPlain);
   });
   std::this_thread::sleep_for(std::chrono::milliseconds(20));
   Socket sock = connectLoopback(ts.port());

--- a/tests/http_headers_custom.cpp
+++ b/tests/http_headers_custom.cpp
@@ -1,0 +1,90 @@
+// Tests for custom header forwarding and reserved header protection
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "aeronet/http-request.hpp"
+#include "aeronet/http-response.hpp"
+#include "aeronet/http-server-config.hpp"
+#include "aeronet/http-server.hpp"
+#include "test_server_fixture.hpp"
+#include "test_util.hpp"
+
+using namespace std::chrono_literals;
+
+TEST(HttpHeadersCustom, ForwardsSingleAndMultipleCustomHeaders) {
+  TestServer ts(aeronet::HttpServerConfig{});
+  ts.server.setHandler([](const aeronet::HttpRequest&) {
+    aeronet::HttpResponse r;
+    r.statusCode(201).reason("Created");
+    r.header("X-One", "1");
+    r.header("X-Two", "two");
+    r.contentType("text/plain");
+    r.body("B");
+    return r;
+  });
+  ClientConnection cc(ts.port());
+  int fd = cc.fd();
+  std::string req = "GET /h HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+  tu_sendAll(fd, req);
+  std::string resp = tu_recvUntilClosed(fd);
+  ASSERT_NE(std::string::npos, resp.find("201 Created"));
+  ASSERT_NE(std::string::npos, resp.find("X-One: 1"));
+  ASSERT_NE(std::string::npos, resp.find("X-Two: two"));
+  ASSERT_NE(std::string::npos, resp.find("Content-Length: 1"));  // auto generated
+  ASSERT_NE(std::string::npos, resp.find("Connection:"));        // auto generated (keep-alive or close)
+}
+
+#ifdef NDEBUG
+// In release builds assertions are disabled; just ensure we can set non-reserved but not crash when attempting what
+// would be reserved (we avoid actually invoking UB). This block left empty intentionally.
+#else
+TEST(HttpHeadersCustom, SettingReservedHeaderTriggersAssert) {
+  // We use EXPECT_DEATH to verify debug assertion fires when user attempts to set reserved headers.
+  TestServer ts(aeronet::HttpServerConfig{});
+  // Connection
+  ASSERT_DEATH(
+      {
+        aeronet::HttpResponse r;
+        r.header("Connection", "keep-alive");
+      },
+      "");
+  // Date
+  ASSERT_DEATH(
+      {
+        aeronet::HttpResponse r;
+        r.header("Date", "Wed, 01 Jan 2020 00:00:00 GMT");
+      },
+      "");
+  // Content-Length
+  ASSERT_DEATH(
+      {
+        aeronet::HttpResponse r;
+        r.header("Content-Length", "10");
+      },
+      "");
+  // Transfer-Encoding
+  ASSERT_DEATH(
+      {
+        aeronet::HttpResponse r;
+        r.header("Transfer-Encoding", "chunked");
+      },
+      "");
+}
+#endif
+
+TEST(HttpHeadersCustom, LocationHeaderAllowed) {
+  TestServer ts(aeronet::HttpServerConfig{});
+  ts.server.setHandler([](const aeronet::HttpRequest&) {
+    aeronet::HttpResponse r;
+    r.statusCode(302).reason("Found").location("/new").body("");
+    return r;
+  });
+  ClientConnection cc(ts.port());
+  int fd = cc.fd();
+  std::string req = "GET /h HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+  tu_sendAll(fd, req);
+  std::string resp = tu_recvUntilClosed(fd);
+  ASSERT_NE(std::string::npos, resp.find("302 Found"));
+  ASSERT_NE(std::string::npos, resp.find("Location: /new"));
+}

--- a/tests/http_keepalive.cpp
+++ b/tests/http_keepalive.cpp
@@ -45,7 +45,7 @@ TEST(HttpKeepAlive, MultipleSequentialRequests) {
   auto port = ts.port();
   ts.server.setHandler([](const aeronet::HttpRequest& req) {
     aeronet::HttpResponse resp;
-    resp.body = std::string("ECHO") + std::string(req.target);
+    resp.body(std::string("ECHO") + std::string(req.target));
     return resp;
   });
 
@@ -79,7 +79,7 @@ TEST(HttpLimits, RejectHugeHeaders) {
   auto port = ts.port();
   ts.server.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse resp;
-    resp.body = "OK";
+    resp.body("OK");
     return resp;
   });
 

--- a/tests/http_malformed.cpp
+++ b/tests/http_malformed.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <chrono>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -28,7 +27,7 @@ std::string sendRaw(uint16_t port, std::string_view raw) {
 TEST(HttpMalformed, MissingSpacesInRequestLine) {
   aeronet::HttpServer server(aeronet::HttpServerConfig{});
   auto port = server.port();
-  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse{}; });
+  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse(200); });
   std::jthread th([&] { server.runUntil([] { return false; }); });
   std::this_thread::sleep_for(50ms);
   std::string resp = sendRaw(port, "GET/abcHTTP/1.1\r\nHost: x\r\n\r\n");
@@ -41,7 +40,7 @@ TEST(HttpMalformed, OversizedHeaders) {
   cfg.withMaxHeaderBytes(64);
   aeronet::HttpServer server(cfg);
   auto port = server.port();
-  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse{}; });
+  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse(200); });
   std::jthread th([&] { server.runUntil([] { return false; }); });
   std::this_thread::sleep_for(50ms);
   std::string big(200, 'A');
@@ -54,7 +53,7 @@ TEST(HttpMalformed, OversizedHeaders) {
 TEST(HttpMalformed, BadChunkExtensionHex) {
   aeronet::HttpServer server(aeronet::HttpServerConfig{});
   auto port = server.port();
-  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse{}; });
+  server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse(200); });
   std::jthread th([&] { server.runUntil([] { return false; }); });
   std::this_thread::sleep_for(50ms);
   // Transfer-Encoding with invalid hex char 'Z'

--- a/tests/http_multi_reuseport.cpp
+++ b/tests/http_multi_reuseport.cpp
@@ -17,7 +17,7 @@ TEST(HttpMultiReusePort, TwoServersBindSamePort) {
   aeronet::HttpServer serverA(aeronet::HttpServerConfig{}.withReusePort());
   serverA.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse resp;
-    resp.body = "A";
+    resp.body("A");
     return resp;
   });
 
@@ -26,7 +26,7 @@ TEST(HttpMultiReusePort, TwoServersBindSamePort) {
   aeronet::HttpServer serverB(aeronet::HttpServerConfig{}.withPort(port).withReusePort());
   serverB.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse resp;
-    resp.body = "B";
+    resp.body("B");
     return resp;
   });
 

--- a/tests/http_multi_wrapper.cpp
+++ b/tests/http_multi_wrapper.cpp
@@ -16,7 +16,7 @@ TEST(MultiHttpServer, BasicStartAndServe) {
   aeronet::MultiHttpServer multi(aeronet::HttpServerConfig{}.withReusePort(), threads);
   multi.setHandler([]([[maybe_unused]] const aeronet::HttpRequest& req) {
     aeronet::HttpResponse resp;
-    resp.body = std::string("Hello "); /* path not exposed directly */
+    resp.body(std::string("Hello ")); /* path not exposed directly */
     return resp;
   });
   multi.start();

--- a/tests/http_parser_errors.cpp
+++ b/tests/http_parser_errors.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <chrono>
 #include <cstddef>
 #include <cstdio>
 #include <mutex>
@@ -35,7 +34,7 @@ TEST(HttpParserErrors, InvalidVersion505) {
   auto port = ts.port();
   Capture cap;
   ts.server.setParserErrorCallback([&](aeronet::HttpServer::ParserError err) { cap.push(err); });
-  ts.server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse{}; });
+  ts.server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse(200); });
   ClientConnection clientConnection(port);
   int fd = clientConnection.fd();
   ASSERT_GE(fd, 0);
@@ -59,7 +58,7 @@ TEST(HttpParserErrors, InvalidVersion505) {
 TEST(HttpParserErrors, Expect100OnlyWithBody) {
   TestServer ts(aeronet::HttpServerConfig{});
   auto port = ts.port();
-  ts.server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse{}; });
+  ts.server.setHandler([](const aeronet::HttpRequest&) { return aeronet::HttpResponse(200); });
   ClientConnection clientConnection(port);
   int fd = clientConnection.fd();
   ASSERT_GE(fd, 0);
@@ -86,11 +85,7 @@ TEST(HttpParserErrors, Expect100OnlyWithBody) {
 TEST(HttpParserErrors, ChunkIncrementalFuzz) {
   TestServer ts(aeronet::HttpServerConfig{});
   auto port = ts.port();
-  ts.server.setHandler([](const aeronet::HttpRequest& req) {
-    aeronet::HttpResponse respObj;
-    respObj.body = std::string(req.body);
-    return respObj;
-  });
+  ts.server.setHandler([](const aeronet::HttpRequest& req) { return aeronet::HttpResponse(200).body(req.body); });
 
   std::mt19937 rng(12345);
   std::uniform_int_distribution<int> sizeDist(1, 15);

--- a/tests/http_routing.cpp
+++ b/tests/http_routing.cpp
@@ -7,6 +7,7 @@
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/http-server.hpp"
+#include "http-constants.hpp"
 #include "http-method-set.hpp"
 #include "http-method.hpp"
 #include "test_http_client.hpp"
@@ -19,21 +20,14 @@ TEST(HttpRouting, BasicPathDispatch) {
   HttpServer server(cfg);
   http::MethodSet helloMethods{http::Method::GET};
   server.addPathHandler("/hello", helloMethods, [](const HttpRequest&) {
-    HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.body = "world";
-    resp.contentType = "text/plain";
-    return resp;
+    return HttpResponse(200).reason("OK").body("world").contentType(aeronet::http::ContentTypeTextPlain);
   });
   http::MethodSet multiMethods{http::Method::GET, http::Method::POST};
   server.addPathHandler("/multi", multiMethods, [](const HttpRequest& req) {
-    HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.body = std::string(req.method) + "!";
-    resp.contentType = "text/plain";
-    return resp;
+    return HttpResponse(200)
+        .reason("OK")
+        .body(std::string(req.method) + "!")
+        .contentType(aeronet::http::ContentTypeTextPlain);
   });
 
   std::atomic<bool> done{false};
@@ -73,13 +67,8 @@ TEST(HttpRouting, BasicPathDispatch) {
 TEST(HttpRouting, GlobalFallbackWithPathHandlers) {
   HttpServerConfig cfg;
   HttpServer server(cfg);
-  server.setHandler([](const HttpRequest&) {
-    HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    return resp;
-  });
+  server.setHandler([](const HttpRequest&) { return HttpResponse(200).reason("OK"); });
   // Adding path handler after global handler is now allowed (Phase 2 mixing model)
   http::MethodSet xMethods{http::Method::GET};
-  EXPECT_NO_THROW(server.addPathHandler("/x", xMethods, [](const HttpRequest&) { return HttpResponse{}; }));
+  EXPECT_NO_THROW(server.addPathHandler("/x", xMethods, [](const HttpRequest&) { return HttpResponse(200); }));
 }

--- a/tests/http_server_move.cpp
+++ b/tests/http_server_move.cpp
@@ -18,7 +18,7 @@ TEST(HttpServerMove, MoveConstructAndServe) {
   auto port = original.port();
   original.setHandler([](const aeronet::HttpRequest& req) {
     aeronet::HttpResponse resp;
-    resp.body = std::string("ORIG:") + std::string(req.target);
+    resp.body(std::string("ORIG:") + std::string(req.target));
     return resp;
   });
 
@@ -44,12 +44,12 @@ TEST(HttpServerMove, MoveAssignWhileStopped) {
 
   s1.setHandler([]([[maybe_unused]] const aeronet::HttpRequest& req) {
     aeronet::HttpResponse resp;
-    resp.body = "S1";
+    resp.body("S1");
     return resp;
   });
   s2.setHandler([]([[maybe_unused]] const aeronet::HttpRequest& req) {
     aeronet::HttpResponse resp;
-    resp.body = "S2";
+    resp.body("S2");
     return resp;
   });
 

--- a/tests/http_stats.cpp
+++ b/tests/http_stats.cpp
@@ -4,6 +4,7 @@
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/http-server.hpp"
+#include "http-constants.hpp"
 #include "test_http_client.hpp"
 #include "test_server_fixture.hpp"
 
@@ -14,12 +15,7 @@ TEST(HttpStats, BasicCountersIncrement) {
   cfg.withMaxRequestsPerConnection(5);
   TestServer ts(cfg);
   ts.server.setHandler([]([[maybe_unused]] const HttpRequest& req) {
-    HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.body = "hello";
-    resp.contentType = "text/plain";
-    return resp;
+    return aeronet::HttpResponse(200).reason("OK").body("hello").contentType(aeronet::http::ContentTypeTextPlain);
   });
   // Single request via throwing helper
   auto resp = test_http_client::request_or_throw(ts.port());

--- a/tests/http_streaming.cpp
+++ b/tests/http_streaming.cpp
@@ -31,8 +31,8 @@ TEST(HttpStreaming, ChunkedSimple) {
   auto port = ts.port();
   ts.server.setStreamingHandler(
       []([[maybe_unused]] const aeronet::HttpRequest& req, aeronet::HttpResponseWriter& writer) {
-        writer.setStatus(200, "OK");
-        writer.setContentType("text/plain");
+        writer.statusCode(200, "OK");
+        writer.contentType("text/plain");
         writer.write("hello ");
         writer.write("world");
         writer.end();
@@ -51,8 +51,8 @@ TEST(HttpStreaming, HeadSuppressedBody) {
   auto port = ts.port();
   ts.server.setStreamingHandler(
       []([[maybe_unused]] const aeronet::HttpRequest& req, aeronet::HttpResponseWriter& writer) {
-        writer.setStatus(200, "OK");
-        writer.setContentType("text/plain");
+        writer.statusCode(200, "OK");
+        writer.contentType("text/plain");
         writer.write("ignored body");  // should not be emitted for HEAD
         writer.end();
       });

--- a/tests/http_streaming_backpressure.cpp
+++ b/tests/http_streaming_backpressure.cpp
@@ -25,7 +25,7 @@ TEST(StreamingBackpressure, LargeBodyQueues) {
   TestServer ts(cfg);
   std::size_t total = static_cast<std::size_t>(512 * 1024);  // 512 KB
   ts.server.setStreamingHandler([&]([[maybe_unused]] const HttpRequest& req, HttpResponseWriter& writer) {
-    writer.setStatus(200, "OK");
+    writer.statusCode(200, "OK");
     std::string chunk(8192, 'x');
     std::size_t sent = 0;
     while (sent < total) {

--- a/tests/http_streaming_head_content_length.cpp
+++ b/tests/http_streaming_head_content_length.cpp
@@ -38,10 +38,10 @@ TEST(HttpStreamingHeadContentLength, HeadSuppressesBodyKeepsCL) {
   TestServer ts(cfg);
   ts.server.setStreamingHandler(
       []([[maybe_unused]] const aeronet::HttpRequest& req, aeronet::HttpResponseWriter& writer) {
-        writer.setStatus(200, "OK");
+        writer.statusCode(200, "OK");
         // We set Content-Length even though we write body pieces; for HEAD the body must be suppressed but CL retained.
         static constexpr std::string_view body = "abcdef";  // length 6
-        writer.setContentLength(body.size());
+        writer.contentLength(body.size());
         writer.write(body.substr(0, 3));
         writer.write(body.substr(3));
         writer.end();

--- a/tests/http_streaming_keepalive.cpp
+++ b/tests/http_streaming_keepalive.cpp
@@ -42,8 +42,7 @@ TEST(StreamingKeepAlive, TwoSequentialRequests) {
   cfg.enableKeepAlive = true;
   HttpServer server(cfg);
   server.setStreamingHandler([](const HttpRequest&, HttpResponseWriter& writer) {
-    writer.setStatus(200, "OK");
-    writer.setHeader("Connection", "keep-alive");
+    writer.statusCode(200, "OK");
     writer.write("hello");
     writer.write(",world");
     writer.end();
@@ -78,8 +77,7 @@ TEST(StreamingKeepAlive, HeadRequestReuse) {
   cfg.enableKeepAlive = true;
   HttpServer server(cfg);
   server.setStreamingHandler([](const HttpRequest&, HttpResponseWriter& writer) {
-    writer.setStatus(200, "OK");
-    writer.setHeader("Connection", "keep-alive");
+    writer.statusCode(200, "OK");
     writer.write("ignored-body");
     writer.end();
   });

--- a/tests/http_streaming_set_header.cpp
+++ b/tests/http_streaming_set_header.cpp
@@ -42,15 +42,15 @@ TEST(HttpStreamingSetHeader, MultipleCustomHeadersAndOverrideContentType) {
   auto port = ts.port();
   ts.server.setStreamingHandler([](const aeronet::HttpRequest& req, aeronet::HttpResponseWriter& writer) {
     bool isHead = req.method == "HEAD";
-    writer.setStatus(200, "OK");
-    writer.setHeader("X-Custom-A", "alpha");
-    writer.setHeader("X-Custom-B", "beta");
-    writer.setHeader("Content-Type", "application/json");  // override default
+    writer.statusCode(200, "OK");
+    writer.header("X-Custom-A", "alpha");
+    writer.header("X-Custom-B", "beta");
+    writer.header("Content-Type", "application/json");  // override default
     // First write sends headers implicitly.
     writer.write("{\"k\":1}");
     // These should be ignored because headers already sent.
-    writer.setHeader("X-Ignored", "zzz");
-    writer.setHeader("Content-Type", "text/plain");
+    writer.header("X-Ignored", "zzz");
+    writer.header("Content-Type", "text/plain");
     writer.end();
     if (isHead) {
       // Nothing extra; body suppressed automatically.

--- a/tests/http_tls_alpn_mismatch.cpp
+++ b/tests/http_tls_alpn_mismatch.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest.h>
 
 #include <string>
-#include <vector>
 
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/server-stats.hpp"
+#include "http-constants.hpp"
 #include "test_server_tls_fixture.hpp"
 #include "test_tls_client.hpp"
 
@@ -17,12 +17,10 @@ TEST(HttpTlsAlpnMismatch, HandshakeFailsWhenNoCommonProtocolAndMustMatch) {
     TlsTestServer ts({"http/1.1", "h2"}, [](aeronet::HttpServerConfig& cfg) { cfg.withTlsAlpnMustMatch(true); });
     auto port = ts.port();
     ts.setHandler([](const aeronet::HttpRequest& req) {
-      aeronet::HttpResponse resp;
-      resp.statusCode = 200;
-      resp.reason = "OK";
-      resp.contentType = "text/plain";
-      resp.body = std::string("ALPN:") + std::string(req.alpnProtocol);
-      return resp;
+      return aeronet::HttpResponse(200)
+          .reason("OK")
+          .contentType(aeronet::http::ContentTypeTextPlain)
+          .body(std::string("ALPN:") + std::string(req.alpnProtocol));
     });
     // Offer only a mismatching ALPN; since TlsClient uses options, construct with protoX.
     TlsClient::Options opts;

--- a/tests/http_tls_alpn_non_strict.cpp
+++ b/tests/http_tls_alpn_non_strict.cpp
@@ -5,6 +5,7 @@
 
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
+#include "http-constants.hpp"
 #include "test_server_tls_fixture.hpp"
 #include "test_tls_client.hpp"
 
@@ -21,12 +22,7 @@ TEST(HttpTlsAlpnNonStrict, MismatchAllowedAndNoMetricIncrement) {
       } else {
         capturedAlpn.clear();
       }
-      aeronet::HttpResponse resp;
-      resp.statusCode = 200;
-      resp.reason = "OK";
-      resp.contentType = "text/plain";
-      resp.body = "NS";
-      return resp;
+      return aeronet::HttpResponse(200).reason("OK").contentType(aeronet::http::ContentTypeTextPlain).body("NS");
     });
     TlsClient::Options opts;
     opts.alpn = {"foo"};  // no overlap

--- a/tests/http_tls_basic.cpp
+++ b/tests/http_tls_basic.cpp
@@ -4,6 +4,7 @@
 
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
+#include "http-constants.hpp"
 #include "test_server_tls_fixture.hpp"
 #include "test_tls_client.hpp"
 
@@ -13,12 +14,10 @@ TEST(HttpTlsBasic, HandshakeAndSimpleGet) {
   {
     TlsTestServer ts;  // ephemeral TLS server
     ts.setHandler([](const aeronet::HttpRequest& req) {
-      aeronet::HttpResponse resp;
-      resp.statusCode = 200;
-      resp.reason = "OK";
-      resp.contentType = "text/plain";
-      resp.body = std::string("TLS OK ") + std::string(req.target);
-      return resp;
+      return aeronet::HttpResponse(200)
+          .reason("OK")
+          .contentType(aeronet::http::ContentTypeTextPlain)
+          .body(std::string("TLS OK ") + std::string(req.target));
     });
     TlsClient client(ts.port());
     raw = client.get("/hello", {{"X-Test", "tls"}});

--- a/tests/http_tls_cipher_version.cpp
+++ b/tests/http_tls_cipher_version.cpp
@@ -7,6 +7,7 @@
 
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
+#include "http-constants.hpp"
 #include "test_server_tls_fixture.hpp"
 #include "test_tls_client.hpp"
 
@@ -24,12 +25,8 @@ TEST(HttpTlsCipherVersion, CipherAndVersionExposedAndMetricsIncrement) {
       capturedCipher = std::string(req.tlsCipher);
       capturedVersion = std::string(req.tlsVersion);
       capturedAlpn = std::string(req.alpnProtocol);
-      aeronet::HttpResponse respOut;
-      respOut.statusCode = 200;
-      respOut.reason = "OK";
-      respOut.contentType = "text/plain";
-      respOut.body = "ok";
-      return respOut;
+
+      return aeronet::HttpResponse(200).reason("OK").contentType(aeronet::http::ContentTypeTextPlain).body("ok");
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(80));  // allow handshake path if needed
     TlsClient::Options opts;

--- a/tests/http_tls_file_certkey.cpp
+++ b/tests/http_tls_file_certkey.cpp
@@ -6,6 +6,7 @@
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
+#include "http-constants.hpp"
 #include "test_server_fixture.hpp"  // reuse generic TestServer with manual config
 #include "test_temp_file.hpp"
 #include "test_tls_client.hpp"
@@ -27,12 +28,10 @@ TEST(HttpTlsFileCertKey, HandshakeSucceedsUsingFileBasedCertAndKey) {
   // Use plain TestServer since we manually set config
   TestServer server(cfg, std::chrono::milliseconds{50});
   server.server.setHandler([](const aeronet::HttpRequest& req) {
-    aeronet::HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.contentType = "text/plain";
-    resp.body = std::string("FILETLS-") + std::string(req.alpnProtocol.empty() ? "-" : req.alpnProtocol);
-    return resp;
+    return aeronet::HttpResponse(200)
+        .reason("OK")
+        .contentType(aeronet::http::ContentTypeTextPlain)
+        .body(std::string("FILETLS-") + std::string(req.alpnProtocol.empty() ? "-" : req.alpnProtocol));
   });
   uint16_t port = server.port();
 

--- a/tests/http_tls_move_alpn.cpp
+++ b/tests/http_tls_move_alpn.cpp
@@ -21,6 +21,7 @@
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/http-server.hpp"
+#include "http-constants.hpp"
 #include "test_tls_client.hpp"
 #include "test_tls_helper.hpp"
 
@@ -35,12 +36,10 @@ TEST(HttpTlsMoveAlpn, MoveConstructBeforeRunMaintainsAlpnHandshake) {
 
   aeronet::HttpServer original(cfg);
   original.setHandler([](const aeronet::HttpRequest& req) {
-    aeronet::HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.contentType = "text/plain";
-    resp.body = std::string("MOVEALPN:") + (req.alpnProtocol.empty() ? "-" : std::string(req.alpnProtocol));
-    return resp;
+    return aeronet::HttpResponse(200)
+        .reason("OK")
+        .contentType(aeronet::http::ContentTypeTextPlain)
+        .body(std::string("MOVEALPN:") + (req.alpnProtocol.empty() ? "-" : std::string(req.alpnProtocol)));
   });
 
   auto port = original.port();

--- a/tests/http_tls_mtls_alpn.cpp
+++ b/tests/http_tls_mtls_alpn.cpp
@@ -5,6 +5,7 @@
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
+#include "http-constants.hpp"
 #include "test_server_tls_fixture.hpp"
 #include "test_tls_client.hpp"
 #include "test_tls_helper.hpp"
@@ -23,12 +24,10 @@ TEST(HttpTlsMtlsAlpn, RequireClientCertHandshakeFailsWithout) {
     });
     auto port = ts.port();
     ts.setHandler([](const aeronet::HttpRequest& req) {
-      aeronet::HttpResponse resp;
-      resp.statusCode = 200;
-      resp.reason = "OK";
-      resp.contentType = "text/plain";
-      resp.body = std::string("SECURE") + std::string(req.target);
-      return resp;
+      return aeronet::HttpResponse(200)
+          .reason("OK")
+          .contentType(aeronet::http::ContentTypeTextPlain)
+          .body(std::string("SECURE") + std::string(req.target));
     });
     TlsClient::Options opts;
     opts.alpn = {"http/1.1"};
@@ -57,12 +56,10 @@ TEST(HttpTlsMtlsAlpn, RequireClientCertSuccessWithAlpn) {
     });
     auto port = ts.port();
     ts.setHandler([](const aeronet::HttpRequest& req) {
-      aeronet::HttpResponse resp;
-      resp.statusCode = 200;
-      resp.reason = "OK";
-      resp.contentType = "text/plain";
-      resp.body = std::string("SECURE") + std::string(req.target);
-      return resp;
+      return aeronet::HttpResponse(200)
+          .reason("OK")
+          .contentType(aeronet::http::ContentTypeTextPlain)
+          .body(std::string("SECURE") + std::string(req.target));
     });
     TlsClient::Options opts;
     opts.alpn = {"http/1.1"};

--- a/tests/http_tls_mtls_metrics.cpp
+++ b/tests/http_tls_mtls_metrics.cpp
@@ -5,6 +5,7 @@
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
+#include "http-constants.hpp"
 #include "test_server_tls_fixture.hpp"
 #include "test_tls_client.hpp"
 #include "test_tls_helper.hpp"
@@ -20,12 +21,7 @@ TEST(HttpTlsMtlsMetrics, ClientCertPresenceIncrementsMetric) {
     });
     auto port = ts.port();
     ts.setHandler([](const aeronet::HttpRequest&) {
-      aeronet::HttpResponse respOut;
-      respOut.statusCode = 200;
-      respOut.reason = "OK";
-      respOut.contentType = "text/plain";
-      respOut.body = "m";
-      return respOut;
+      return aeronet::HttpResponse(200).reason("OK").contentType(aeronet::http::ContentTypeTextPlain).body("m");
     });
     [[maybe_unused]] auto before = ts.stats();
     TlsClient::Options opts;

--- a/tests/http_tls_negative.cpp
+++ b/tests/http_tls_negative.cpp
@@ -6,6 +6,7 @@
 
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
+#include "http-constants.hpp"
 #include "test_server_tls_fixture.hpp"
 #include "test_tls_client.hpp"
 #include "test_util.hpp"
@@ -51,12 +52,10 @@ TEST(HttpTlsNegative, LargeResponseFragmentation) {
     TlsTestServer ts;  // basic TLS
     auto port = ts.port();
     ts.setHandler([](const aeronet::HttpRequest&) {
-      aeronet::HttpResponse resp;
-      resp.statusCode = 200;
-      resp.reason = "OK";
-      resp.contentType = "text/plain";
-      resp.body.assign(300000, 'A');
-      return resp;
+      return aeronet::HttpResponse(200)
+          .reason("OK")
+          .contentType(aeronet::http::ContentTypeTextPlain)
+          .body(std::string(300000, 'A'));
     });
     resp = tlsGetLarge(port);
     ts.stop();

--- a/tests/http_tls_request_client_cert_optional.cpp
+++ b/tests/http_tls_request_client_cert_optional.cpp
@@ -6,6 +6,7 @@
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
+#include "http-constants.hpp"
 #include "test_server_tls_fixture.hpp"
 #include "test_tls_client.hpp"
 #include "test_tls_helper.hpp"
@@ -20,14 +21,13 @@ TEST(HttpTlsRequestClientCert, OptionalNoClientCertAccepted) {
     TlsTestServer ts({}, [](aeronet::HttpServerConfig& cfg) { cfg.withTlsRequestClientCert(true); });
     auto port = ts.port();
     ts.setHandler([&](const aeronet::HttpRequest& req) {
-      aeronet::HttpResponse resp;
-      resp.statusCode = 200;
-      resp.reason = "OK";
-      resp.contentType = "text/plain";
+      aeronet::HttpResponse resp(200);
+      resp.reason("OK");
+      resp.contentType(aeronet::http::ContentTypeTextPlain);
       if (!req.tlsCipher.empty()) {
-        resp.body = std::string("REQ-") + std::string(req.tlsCipher);
+        resp.body(std::string("REQ-") + std::string(req.tlsCipher));
       } else {
-        resp.body = "REQ-";
+        resp.body("REQ-");
       }
       return resp;
     });
@@ -54,12 +54,11 @@ TEST(HttpTlsRequestClientCert, OptionalWithClientCertIncrementsMetric) {
     });
     auto port = ts.port();
     ts.setHandler([](const aeronet::HttpRequest&) {
-      aeronet::HttpResponse resp;
-      resp.statusCode = 200;
-      resp.reason = "OK";
-      resp.contentType = "text/plain";
-      resp.body = "C";
-      return resp;
+      return aeronet::HttpResponse()
+          .statusCode(200)
+          .reason("OK")
+          .contentType(aeronet::http::ContentTypeTextPlain)
+          .body("C");
     });
     TlsClient::Options opts;
     opts.clientCertPem = clientPair.first;

--- a/tests/http_tls_version_bounds.cpp
+++ b/tests/http_tls_version_bounds.cpp
@@ -6,6 +6,7 @@
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
+#include "http-constants.hpp"
 #include "test_server_tls_fixture.hpp"
 #include "test_tls_client.hpp"
 
@@ -21,12 +22,8 @@ TEST(HttpTlsVersionBounds, MinMaxTls12Forces12) {
       if (!req.tlsVersion.empty()) {
         capturedVersion = std::string(req.tlsVersion);
       }
-      aeronet::HttpResponse resp;
-      resp.statusCode = 200;
-      resp.reason = "OK";
-      resp.contentType = "text/plain";
-      resp.body = "V";
-      return resp;
+
+      return aeronet::HttpResponse(200).reason("OK").contentType(aeronet::http::ContentTypeTextPlain).body("V");
     });
     TlsClient::Options opts;
     opts.alpn = {"http/1.1"};

--- a/tests/http_trailing_slash.cpp
+++ b/tests/http_trailing_slash.cpp
@@ -1,0 +1,194 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "aeronet/http-server-config.hpp"
+#include "aeronet/http-server.hpp"
+#include "test_http_client.hpp"
+#include "test_server_fixture.hpp"
+
+using aeronet::HttpServerConfig;
+
+namespace {
+std::string rawRequest(uint16_t port, const std::string& target) {
+  test_http_client::RequestOptions opt;
+  opt.method = "GET";
+  opt.target = target;
+  opt.connection = "close";
+  auto resp = test_http_client::request(port, opt);
+  return resp.value_or("");
+}
+
+}  // namespace
+
+TEST(HttpTrailingSlash, StrictPolicyDifferent) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Strict);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/alpha", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("alpha"); });
+  auto resp = rawRequest(ts.port(), "/alpha/");
+  ts.stop();
+  if (resp.find("404") == std::string::npos) {
+    std::cerr << "[DEBUG StrictPolicyDifferent] Raw response (len=" << resp.size() << "):\n" << resp << '\n';
+  }
+  ASSERT_NE(std::string::npos, resp.find("404"));
+}
+
+TEST(HttpTrailingSlash, NormalizePolicyStrips) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Normalize);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/beta", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("beta"); });
+  auto resp = rawRequest(ts.port(), "/beta/");
+  ts.stop();
+  ASSERT_NE(std::string::npos, resp.find("200"));
+  ASSERT_NE(std::string::npos, resp.find("beta"));
+}
+
+TEST(HttpTrailingSlash, RedirectPolicy) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Redirect);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/gamma", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("gamma"); });
+  auto resp = rawRequest(ts.port(), "/gamma/");
+  ts.stop();
+  // Expect 301 and Location header
+  ASSERT_NE(std::string::npos, resp.find("301"));
+  ASSERT_NE(std::string::npos, resp.find("Location: /gamma\r\n"));
+}
+
+// Additional matrix coverage
+
+TEST(HttpTrailingSlash, StrictPolicyRegisteredWithSlashDoesNotMatchWithout) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Strict);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/sigma/", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("sigma"); });
+  auto ok = rawRequest(ts.port(), "/sigma/");
+  auto notFound = rawRequest(ts.port(), "/sigma");
+  ts.stop();
+  if (ok.find("200") == std::string::npos) {
+    std::cerr << "[DEBUG StrictPolicyRegisteredWithSlashDoesNotMatchWithout] OK Raw (len=" << ok.size() << "):\n"
+              << ok << '\n';
+  }
+  ASSERT_NE(std::string::npos, ok.find("200"));
+  ASSERT_NE(std::string::npos, notFound.find("404"));
+}
+
+TEST(HttpTrailingSlash, NormalizePolicyRegisteredWithSlashAcceptsWithout) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Normalize);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/norm/", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("norm"); });
+  auto withSlash = rawRequest(ts.port(), "/norm/");
+  auto withoutSlash = rawRequest(ts.port(), "/norm");
+  ts.stop();
+  if (withSlash.find("200") == std::string::npos) {
+    std::cerr << "[DEBUG NormalizePolicyRegisteredWithSlashAcceptsWithout] withSlash Raw (len=" << withSlash.size()
+              << "):\n"
+              << withSlash << '\n';
+  }
+  ASSERT_NE(std::string::npos, withSlash.find("200"));
+  ASSERT_NE(std::string::npos, withoutSlash.find("200"));
+  ASSERT_NE(std::string::npos, withoutSlash.find("norm"));
+}
+
+TEST(HttpTrailingSlash, RedirectPolicyCanonicalOnlyMatchesWithoutSlash) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Redirect);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/redir", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("redir"); });
+  auto redirect = rawRequest(ts.port(), "/redir/");  // should 301 -> /redir
+  auto canonical = rawRequest(ts.port(), "/redir");  // should 200
+  ts.stop();
+  ASSERT_NE(std::string::npos, redirect.find("301"));
+  ASSERT_NE(std::string::npos, redirect.find("Location: /redir\r\n"));
+  ASSERT_NE(std::string::npos, canonical.find("200"));
+  ASSERT_NE(std::string::npos, canonical.find("redir"));
+}
+
+TEST(HttpTrailingSlash, RedirectPolicyRegisteredWithSlashDoesNotAddSlash) {
+  // Current behavior: if only "/only/" is registered and Redirect policy set, request to "/only" is 404 (no inverse
+  // redirect)
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Redirect);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/only/", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("only"); });
+  auto withSlash = rawRequest(ts.port(), "/only/");
+  auto withoutSlash = rawRequest(ts.port(), "/only");
+  ts.stop();
+  ASSERT_NE(std::string::npos, withSlash.find("200"));
+  ASSERT_NE(std::string::npos, withoutSlash.find("404"));
+}
+
+TEST(HttpTrailingSlash, RootPathNotRedirected) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Redirect);
+  TestServer ts(cfg);
+  auto resp = rawRequest(ts.port(), "/");  // no handlers => 404 but not 301
+  ts.stop();
+  ASSERT_NE(std::string::npos, resp.find("404"));
+  ASSERT_EQ(std::string::npos, resp.find("301"));
+}
+
+// ================= Additional tests for exact-match-first semantics =================
+
+TEST(HttpTrailingSlash, RedirectPolicyBothVariants_NoRedirectWhenExact) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Redirect);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/dual", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("dual-no-slash"); });
+  ts.server.addPathHandler("/dual/", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("dual-with-slash"); });
+  auto respNoSlash = rawRequest(ts.port(), "/dual");
+  auto respWithSlash = rawRequest(ts.port(), "/dual/");
+  ts.stop();
+  ASSERT_NE(std::string::npos, respNoSlash.find("200"));
+  ASSERT_NE(std::string::npos, respNoSlash.find("dual-no-slash"));
+  ASSERT_NE(std::string::npos, respWithSlash.find("200"));
+  ASSERT_NE(std::string::npos, respWithSlash.find("dual-with-slash"));
+  // Crucially: no 301 redirect should appear because exact matches exist for both requests.
+  ASSERT_EQ(std::string::npos, respWithSlash.find("301"));
+}
+
+TEST(HttpTrailingSlash, NormalizePolicyBothVariants_Independent) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Normalize);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/sep", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("sep-no-slash"); });
+  ts.server.addPathHandler("/sep/", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("sep-with-slash"); });
+  auto respNoSlash = rawRequest(ts.port(), "/sep");
+  auto respWithSlash = rawRequest(ts.port(), "/sep/");
+  ts.stop();
+  ASSERT_NE(std::string::npos, respNoSlash.find("200"));
+  ASSERT_NE(std::string::npos, respNoSlash.find("sep-no-slash"));
+  ASSERT_NE(std::string::npos, respWithSlash.find("200"));
+  ASSERT_NE(std::string::npos, respWithSlash.find("sep-with-slash"));
+}
+
+TEST(HttpTrailingSlash, StrictPolicyBothVariants_Independent) {
+  HttpServerConfig cfg{};
+  cfg.withTrailingSlashPolicy(HttpServerConfig::TrailingSlashPolicy::Strict);
+  TestServer ts(cfg);
+  ts.server.addPathHandler("/both", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("both-no-slash"); });
+  ts.server.addPathHandler("/both/", aeronet::http::Method::GET,
+                           [](const aeronet::HttpRequest&) { return aeronet::HttpResponse().body("both-with-slash"); });
+  auto respNoSlash = rawRequest(ts.port(), "/both");
+  auto respWithSlash = rawRequest(ts.port(), "/both/");
+  ts.stop();
+  ASSERT_NE(std::string::npos, respNoSlash.find("200"));
+  ASSERT_NE(std::string::npos, respNoSlash.find("both-no-slash"));
+  ASSERT_NE(std::string::npos, respWithSlash.find("200"));
+  ASSERT_NE(std::string::npos, respWithSlash.find("both-with-slash"));
+}

--- a/tests/http_url_decoding.cpp
+++ b/tests/http_url_decoding.cpp
@@ -10,6 +10,7 @@
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/http-server.hpp"
+#include "http-constants.hpp"
 #include "http-method-set.hpp"
 #include "http-method.hpp"
 #include "test_http_client.hpp"
@@ -24,12 +25,10 @@ TEST(HttpUrlDecoding, SpaceDecoding) {
   HttpServer server(cfg);
   http::MethodSet ms{http::Method::GET};
   server.addPathHandler("/hello world", ms, [](const HttpRequest &req) {
-    HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.body = std::string(req.target);
-    resp.contentType = "text/plain";
-    return resp;
+    return aeronet::HttpResponse(200)
+        .reason("OK")
+        .body(std::string(req.target))
+        .contentType(http::ContentTypeTextPlain);
   });
   std::atomic<bool> done{false};
   std::jthread th([&] { server.runUntil([&] { return done.load(); }); });
@@ -54,12 +53,7 @@ TEST(HttpUrlDecoding, Utf8Decoded) {
   // Path contains snowman + space + 'x'
   std::string decodedPath = "/\xE2\x98\x83 x";  // /☃ x
   server.addPathHandler(decodedPath, ms, [](const HttpRequest &) {
-    HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.body = "utf8";
-    resp.contentType = "text/plain";
-    return resp;
+    return aeronet::HttpResponse(200).reason("OK").body("utf8").contentType(http::ContentTypeTextPlain);
   });
   std::atomic<bool> done{false};
   std::jthread th([&] { server.runUntil([&] { return done.load(); }); });
@@ -83,12 +77,7 @@ TEST(HttpUrlDecoding, PlusIsNotSpace) {
   HttpServer server(cfg);
   http::MethodSet ms{http::Method::GET};
   server.addPathHandler("/a+b", ms, [](const HttpRequest &) {
-    HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.body = "plus";
-    resp.contentType = "text/plain";
-    return resp;
+    return aeronet::HttpResponse(200).reason("OK").body("plus").contentType(http::ContentTypeTextPlain);
   });
   std::atomic<bool> done{false};
   std::jthread th([&] { server.runUntil([&] { return done.load(); }); });

--- a/tests/http_url_decoding_additional.cpp
+++ b/tests/http_url_decoding_additional.cpp
@@ -9,6 +9,7 @@
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/http-server.hpp"
+#include "http-constants.hpp"
 #include "http-method-set.hpp"
 #include "http-method.hpp"
 #include "test_http_client.hpp"
@@ -40,12 +41,7 @@ TEST(HttpUrlDecodingExtra, MixedSegmentsDecoding) {
   HttpServer server(cfg);
   http::MethodSet ms{http::Method::GET};
   server.addPathHandler("/seg one/part%/two", ms, [](const HttpRequest &req) {
-    HttpResponse resp;
-    resp.statusCode = 200;
-    resp.reason = "OK";
-    resp.body = std::string(req.target);
-    resp.contentType = "text/plain";
-    return resp;
+    return aeronet::HttpResponse(200).reason("OK").body(req.target).contentType(aeronet::http::ContentTypeTextPlain);
   });
   std::atomic<bool> done = false;
   std::jthread th([&] { server.runUntil([&] { return done.load(); }); });

--- a/tests/multi_http_server_convenience_constructors.cpp
+++ b/tests/multi_http_server_convenience_constructors.cpp
@@ -53,7 +53,7 @@ TEST(MultiHttpServer, AutoThreadCountConstructor) {
   aeronet::MultiHttpServer multi(cfg);
   multi.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse resp;
-    resp.body = "Auto";
+    resp.body("Auto");
     return resp;
   });
   multi.start();
@@ -77,7 +77,7 @@ TEST(MultiHttpServer, ExplicitThreadCountConstructor) {
   aeronet::MultiHttpServer multi(cfg, threads);
   multi.setHandler([]([[maybe_unused]] const aeronet::HttpRequest& req) {
     aeronet::HttpResponse resp;
-    resp.body = "Explicit";
+    resp.body("Explicit");
     return resp;
   });
   multi.start();
@@ -97,7 +97,7 @@ TEST(MultiHttpServer, MoveConstruction) {
   aeronet::MultiHttpServer original(cfg);  // auto threads
   original.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse resp;
-    resp.body = "Move";
+    resp.body("Move");
     return resp;
   });
   original.start();
@@ -132,7 +132,7 @@ TEST(MultiHttpServer, DefaultConstructorAndMoveAssignment) {
   aeronet::MultiHttpServer running(cfg);  // auto thread count
   running.setHandler([](const aeronet::HttpRequest&) {
     aeronet::HttpResponse resp;
-    resp.body = "MoveAssign";
+    resp.body("MoveAssign");
     return resp;
   });
   running.start();


### PR DESCRIPTION
- Implement configurable path trailing slash policy
- Improve `HttpResponse` builder client usage thanks to simple builder pattern
- Implement correctly `Connection: close` in streaming in client asks for it