### PR TITLE
feat: allow empty value headers

### DIFF
--- a/aeronet/http/include/connection-state.hpp
+++ b/aeronet/http/include/connection-state.hpp
@@ -11,6 +11,20 @@
 namespace aeronet {
 
 struct ConnectionState {
+  // Request to close immediately (abort outstanding buffered writes).
+  void requestImmediateClose() { closeMode = CloseMode::Immediate; }
+
+  // Request to close after draining currently buffered writes (graceful half-close semantics).
+  void requestDrainAndClose() {
+    if (closeMode == CloseMode::None) {
+      closeMode = CloseMode::DrainThenClose;
+    }
+  }
+
+  [[nodiscard]] bool isImmediateCloseRequested() const noexcept { return closeMode == CloseMode::Immediate; }
+  [[nodiscard]] bool isDrainCloseRequested() const noexcept { return closeMode == CloseMode::DrainThenClose; }
+  [[nodiscard]] bool isAnyCloseRequested() const noexcept { return closeMode != CloseMode::None; }
+
   RawChars buffer;                        // accumulated raw data
   RawChars bodyStorage;                   // decoded body lifetime
   RawChars outBuffer;                     // pending outbound bytes not yet written
@@ -20,12 +34,14 @@ struct ConnectionState {
   // Reset when a complete request head is parsed. If std::chrono::steady_clock::time_point{} (epoch) -> inactive.
   std::chrono::steady_clock::time_point headerStart;  // default epoch value means no header timing active
   uint32_t requestsServed{0};
-  bool shouldClose{false};      // request to close once outBuffer drains
-  bool waitingWritable{false};  // EPOLLOUT registered
-  bool tlsEstablished{false};   // true once TLS handshake completed (if TLS enabled)
-  bool tlsWantRead{false};      // last transport op indicated WANT_READ
-  bool tlsWantWrite{false};     // last transport op indicated WANT_WRITE
-  // TODO: maybe we could add closeConnection bool here
+  // Connection close lifecycle.
+  enum class CloseMode : uint8_t { None, DrainThenClose, Immediate };
+
+  CloseMode closeMode{CloseMode::None};
+  bool waitingWritable{false};                           // EPOLLOUT registered
+  bool tlsEstablished{false};                            // true once TLS handshake completed (if TLS enabled)
+  bool tlsWantRead{false};                               // last transport op indicated WANT_READ
+  bool tlsWantWrite{false};                              // last transport op indicated WANT_WRITE
   std::string selectedAlpn;                              // negotiated ALPN protocol (if any)
   std::string negotiatedCipher;                          // negotiated TLS cipher suite (if TLS)
   std::string negotiatedVersion;                         // negotiated TLS protocol version string

--- a/aeronet/http/src/http-request.cpp
+++ b/aeronet/http/src/http-request.cpp
@@ -56,8 +56,16 @@ void HttpRequest::QueryParamRange::iterator::advance() {
   }
 }
 
-std::string_view HttpRequest::header(std::string_view key) const {
-  const auto it = headers().find(key);
+std::string_view HttpRequest::headerValueOrEmpty(std::string_view headerKey) const noexcept {
+  const auto it = headers().find(headerKey);
+  if (it != headers().end()) {
+    return it->second;
+  }
+  return {};
+}
+
+std::optional<std::string_view> HttpRequest::headerValue(std::string_view headerKey) const noexcept {
+  const auto it = headers().find(headerKey);
   if (it != headers().end()) {
     return it->second;
   }
@@ -65,7 +73,7 @@ std::string_view HttpRequest::header(std::string_view key) const {
 }
 
 [[nodiscard]] bool HttpRequest::wantClose() const {
-  std::string_view connVal = header(http::Connection);
+  std::string_view connVal = headerValueOrEmpty(http::Connection);
   if (connVal.size() == http::close.size()) {
     for (std::size_t iChar = 0; iChar < http::close.size(); ++iChar) {
       const char lhs = tolower(connVal[iChar]);

--- a/aeronet/http/test/http-request_test.cpp
+++ b/aeronet/http/test/http-request_test.cpp
@@ -30,12 +30,18 @@ std::string BuildRaw(std::string_view method, std::string_view target, std::stri
 }
 }  // namespace
 
-TEST(HttpRequestUnit, ParseBasicPathAndVersion) {
+class HttpRequestTest : public ::testing::Test {
+ protected:
+  http::StatusCode reqSet(std::size_t maxHeaderSize = 4096UL) { return req.setHead(cs, maxHeaderSize); }
+
   HttpRequest req;
   ConnectionState cs;
+};
+
+TEST_F(HttpRequestTest, ParseBasicPathAndVersion) {
   auto raw = BuildRaw("GET", "/abc", "HTTP/1.1");
   cs.buffer.assign(raw.data(), raw.data() + raw.size());
-  auto st = req.setHead(cs, 4096UL);
+  auto st = reqSet();
   EXPECT_EQ(st, http::StatusCodeOK);
   EXPECT_EQ(req.method(), http::Method::GET);
   EXPECT_EQ(req.path(), "/abc");
@@ -43,13 +49,11 @@ TEST(HttpRequestUnit, ParseBasicPathAndVersion) {
   EXPECT_TRUE(req.queryParams().begin() == req.queryParams().end());
 }
 
-TEST(HttpRequestUnit, QueryParamsDecodingPlusAndPercent) {
-  HttpRequest req;
-  ConnectionState cs;
+TEST_F(HttpRequestTest, QueryParamsDecodingPlusAndPercent) {
   // a=1+2&b=hello%20world&c=%zz (malformed % sequence left verbatim for c's value)
   auto raw = BuildRaw("GET", "/p?a=1+2&b=hello%20world&c=%zz");
   cs.buffer.assign(raw.data(), raw.data() + raw.size());
-  auto st = req.setHead(cs, 4096UL);
+  auto st = reqSet();
   ASSERT_EQ(st, http::StatusCodeOK);
   std::vector<std::pair<std::string_view, std::string_view>> seen;
   for (auto [k, v] : req.queryParams()) {
@@ -64,12 +68,10 @@ TEST(HttpRequestUnit, QueryParamsDecodingPlusAndPercent) {
   EXPECT_EQ(seen[2].second, "%zz");  // invalid escape left as-is
 }
 
-TEST(HttpRequestUnit, EmptyAndMissingValues) {
-  HttpRequest req;
-  ConnectionState cs;
+TEST_F(HttpRequestTest, EmptyAndMissingValues) {
   auto raw = BuildRaw("GET", "/p?k1=&k2&=v");
   cs.buffer.assign(raw.data(), raw.data() + raw.size());
-  auto st = req.setHead(cs, 4096UL);
+  auto st = reqSet();
   ASSERT_EQ(st, http::StatusCodeOK);
   std::vector<std::pair<std::string_view, std::string_view>> seen;
   for (auto [k, v] : req.queryParams()) {
@@ -84,12 +86,10 @@ TEST(HttpRequestUnit, EmptyAndMissingValues) {
   EXPECT_EQ(seen[2].second, "v");
 }
 
-TEST(HttpRequestUnit, DuplicateKeysPreservedOrder) {
-  HttpRequest req;
-  ConnectionState cs;
+TEST_F(HttpRequestTest, DuplicateKeysPreservedOrder) {
   auto raw = BuildRaw("GET", "/p?x=1&x=2&x=3");
   cs.buffer.assign(raw.data(), raw.data() + raw.size());
-  auto st = req.setHead(cs, 4096UL);
+  auto st = reqSet();
   ASSERT_EQ(st, http::StatusCodeOK);
   std::vector<std::string_view> values;
   for (auto [k, v] : req.queryParams()) {
@@ -103,13 +103,67 @@ TEST(HttpRequestUnit, DuplicateKeysPreservedOrder) {
   EXPECT_EQ(values[2], "3");
 }
 
-TEST(HttpRequestUnit, InvalidPathEscapeCauses400) {
-  HttpRequest req;
-  ConnectionState cs;
+TEST_F(HttpRequestTest, InvalidPathEscapeCauses400) {
   auto raw = BuildRaw("GET", "/bad%zz");
   cs.buffer.assign(raw.data(), raw.data() + raw.size());
-  auto st = req.setHead(cs, 4096UL);
+  auto st = reqSet();
   EXPECT_EQ(st, http::StatusCodeBadRequest);
+}
+
+TEST_F(HttpRequestTest, HeaderAccessorsBasicAndEmptyVsMissing) {
+  // Provide headers including:
+  //  - normal value (X-Test)
+  //  - empty value (X-Empty)
+  //  - value with trailing spaces (X-Trim)
+  //  - value with leading & trailing mixed whitespace (X-Spaces)
+  //  - lowercase key to verify case-insensitive lookup (content-length)
+  auto raw = BuildRaw("GET", "/p", "HTTP/1.1",
+                      "X-Test: Value\r\n"
+                      "X-Empty:\r\n"
+                      "X-Trim: value   \r\n"
+                      "X-Spaces:    abc \t  \r\n"
+                      "content-length: 0\r\n");
+  cs.buffer.assign(raw.data(), raw.data() + raw.size());
+  auto st = reqSet();
+  ASSERT_EQ(st, http::StatusCodeOK);
+
+  // Existing normal header
+  EXPECT_EQ(req.headerValueOrEmpty("X-Test"), "Value");
+  auto optVal = req.headerValue("X-Test");
+  ASSERT_TRUE(optVal.has_value());
+  EXPECT_EQ(*optVal, "Value");
+
+  // Case-insensitive lookup
+  EXPECT_EQ(req.headerValueOrEmpty("x-test"), "Value");
+  EXPECT_TRUE(req.headerValue("x-test").has_value());
+
+  // Empty header value vs missing header
+  EXPECT_EQ(req.headerValueOrEmpty("X-Empty"), "");
+  auto optEmpty = req.headerValue("X-Empty");
+  ASSERT_TRUE(optEmpty.has_value());
+  EXPECT_EQ(*optEmpty, "");
+
+  // Trimming behavior (trailing)
+  EXPECT_EQ(req.headerValueOrEmpty("X-Trim"), "value");
+  EXPECT_EQ(req.headerValueOrEmpty("x-trim"), "value");
+  // Trimming behavior (leading & trailing)
+  EXPECT_EQ(req.headerValueOrEmpty("X-Spaces"), "abc");
+  auto optSpaces = req.headerValue("X-Spaces");
+  ASSERT_TRUE(optSpaces.has_value());
+  EXPECT_EQ(*optSpaces, "abc");
+
+  EXPECT_EQ(req.headerValueOrEmpty("No-Such"), std::string_view());
+  EXPECT_FALSE(req.headerValue("No-Such").has_value());
+}
+
+TEST_F(HttpRequestTest, HeaderAccessorsAbsentHeaders) {
+  auto raw = BuildRaw("GET", "/p");
+  cs.buffer.assign(raw.data(), raw.data() + raw.size());
+  auto st = reqSet();
+  ASSERT_EQ(st, http::StatusCodeOK);
+  EXPECT_EQ(req.headerValueOrEmpty("Host"), "h");  // baseline sanity
+  EXPECT_EQ(req.headerValueOrEmpty("X-Unknown"), std::string_view());
+  EXPECT_FALSE(req.headerValue("X-Unknown").has_value());
 }
 
 }  // namespace aeronet

--- a/aeronet/main/include/aeronet/http-server.hpp
+++ b/aeronet/main/include/aeronet/http-server.hpp
@@ -322,19 +322,18 @@ class HttpServer {
   void handleReadableClient(int fd);
   bool processRequestsOnConnection(int fd, ConnectionState& state);
   // Split helpers
-  std::size_t parseNextRequestFromBuffer(int fd, ConnectionState& state, HttpRequest& outReq, bool& closeConnection);
+  std::size_t parseNextRequestFromBuffer(int fd, ConnectionState& state, HttpRequest& outReq);
   bool decodeBodyIfReady(int fd, ConnectionState& state, const HttpRequest& req, bool isChunked, bool expectContinue,
-                         bool& closeConnection, std::size_t& consumedBytes);
+                         std::size_t& consumedBytes);
   bool decodeFixedLengthBody(int fd, ConnectionState& state, const HttpRequest& req, bool expectContinue,
-                             bool& closeConnection, std::size_t& consumedBytes);
+                             std::size_t& consumedBytes);
   bool decodeChunkedBody(int fd, ConnectionState& state, const HttpRequest& req, bool expectContinue,
-                         bool& closeConnection, std::size_t& consumedBytes);
+                         std::size_t& consumedBytes);
   void finalizeAndSendResponse(int fd, ConnectionState& state, HttpRequest& req, HttpResponse& resp,
-                               std::size_t consumedBytes, std::chrono::steady_clock::time_point reqStart,
-                               bool& closeConnection);
-  // Helper to build & queue a simple error response, invoke parser error callback (if any),
-  // mark connection for closure and return false for convenient tail calls in parsing paths.
-  void emitSimpleError(int fd, ConnectionState& state, http::StatusCode code, bool& closeConnection);
+                               std::size_t consumedBytes, std::chrono::steady_clock::time_point reqStart);
+  // Helper to build & queue a simple error response, invoke parser error callback (if any).
+  // If immediate=true the connection will be closed without waiting for buffered writes to drain.
+  void emitSimpleError(int fd, ConnectionState& state, http::StatusCode code, bool immediate = false);
   // Outbound write helpers
   bool queueData(int fd, ConnectionState& state, std::string_view data);
   void flushOutbound(int fd, ConnectionState& state);

--- a/aeronet/main/include/aeronet/multi-http-server.hpp
+++ b/aeronet/main/include/aeronet/multi-http-server.hpp
@@ -76,7 +76,7 @@ class MultiHttpServer {
   MultiHttpServer& operator=(const MultiHttpServer&) = delete;
   MultiHttpServer& operator=(MultiHttpServer&& other) noexcept;
 
-  ~MultiHttpServer() { stop(); }
+  ~MultiHttpServer();
 
   // setHandler:
   //   Registers a single global handler applied to all successfully parsed requests on every

--- a/aeronet/main/src/http-response-writer.cpp
+++ b/aeronet/main/src/http-response-writer.cpp
@@ -280,7 +280,7 @@ bool HttpResponseWriter::write(std::string_view data) {
     _bytesWritten += data.size();
   }
   log::trace("Streaming: write fd={} size={} total={} chunked={}", _fd, data.size(), _bytesWritten, _chunked);
-  return !_failed;  // backpressure signaled via server.shouldClose flag, failure sets _failed
+  return !_failed;  // backpressure signaled via connection close flag, failure sets _failed
 }
 
 void HttpResponseWriter::end() {
@@ -343,7 +343,7 @@ bool HttpResponseWriter::enqueue(std::string_view data) {
   }
   auto& st = it->second;
   bool ok = _server->queueData(_fd, st, data);
-  return ok && !st.shouldClose;
+  return ok && !st.isAnyCloseRequested();
 }
 
 }  // namespace aeronet

--- a/aeronet/main/src/multi-http-server.cpp
+++ b/aeronet/main/src/multi-http-server.cpp
@@ -89,6 +89,8 @@ MultiHttpServer& MultiHttpServer::operator=(MultiHttpServer&& other) noexcept {
   return *this;
 }
 
+MultiHttpServer::~MultiHttpServer() { stop(); }
+
 [[nodiscard]] std::string MultiHttpServer::AggregatedStats::json_str() const {
   std::string out;
   out.reserve(128UL * per.size());
@@ -186,15 +188,12 @@ void MultiHttpServer::stop() {
     return;
   }
   log::info("MultiHttpServer stopping (instances={})", _servers.size());
-  for (auto& srvPtr : _servers) {
-    srvPtr.stop();
-  }
+  std::ranges::for_each(_servers, [](auto& server) { server.stop(); });
+
+  _threads.clear();
 
   _running = false;
   log::info("MultiHttpServer stopped");
-  // mutex unlocked at end of scope prior to join
-  // join outside lock
-  // (scope exit lock unlock happens here)
 }
 
 MultiHttpServer::AggregatedStats MultiHttpServer::stats() const {

--- a/tests/http_routing.cpp
+++ b/tests/http_routing.cpp
@@ -31,7 +31,7 @@ TEST(HttpRouting, BasicPathDispatch) {
 
   std::atomic<bool> done{false};
   std::jthread th([&]() { server.runUntil([&]() { return done.load(); }); });
-  for (int i = 0; i < 200 && (!server.isRunning() || server.port() == 0); ++i) {
+  for (int i = 0; i < 200 && !server.isRunning(); ++i) {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
   }
 

--- a/tests/multi_http_server_stress.cpp
+++ b/tests/multi_http_server_stress.cpp
@@ -23,7 +23,6 @@ TEST(MultiHttpServer, RapidStartStopCycles) {
     });
     multi.start();
     ASSERT_TRUE(multi.isRunning());
-    ASSERT_GT(multi.port(), 0);
     // Short dwell to allow threads to enter run loop.
     std::this_thread::sleep_for(5ms);
     multi.stop();


### PR DESCRIPTION
Now headers with empty values can be retrieved (previous method `header()` returned an empty `std::string_view` for both absence of an header, or empty value. Now we have two methods that are well documented in the `HttpRequest`:
 - headerValue returns an `std::optional<std::string_view>`
 - headerValueOrEmpty corresponds to previous `header()`'s behavior (empty if not present)
 
 Also some code clean-up around `closeConnection`.