### PR TITLE
fix: large payloads are now handled correctly for TLS & plain

### DIFF
--- a/aeronet/http/include/aeronet/http-request.hpp
+++ b/aeronet/http/include/aeronet/http-request.hpp
@@ -146,7 +146,8 @@ class HttpRequest {
 
   // Attempts to set this HttpRequest (except body) from given ConnectionState.
   // Returns StatusCode OK if the request is good (it will be fully set)
-  // Or an HTTP error status to forward.
+  // or an HTTP error status to forward.
+  // If 0 is returned, it means the connection state buffer is not filled up to the first newline.
   http::StatusCode setHead(ConnectionState& state, RawChars& tmpBuffer, std::size_t maxHeadersBytes,
                            bool mergeAllowedForUnknownRequestHeaders);
 

--- a/aeronet/http/include/connection-state.hpp
+++ b/aeronet/http/include/connection-state.hpp
@@ -29,8 +29,8 @@ struct ConnectionState {
   [[nodiscard]] bool isDrainCloseRequested() const noexcept { return closeMode == CloseMode::DrainThenClose; }
   [[nodiscard]] bool isAnyCloseRequested() const noexcept { return closeMode != CloseMode::None; }
 
-  ssize_t transportRead(std::size_t chunkSize, bool& wantRead, bool& wantWrite);
-  ssize_t transportWrite(std::string_view data, bool& wantRead, bool& wantWrite) const;
+  ssize_t transportRead(std::size_t chunkSize, TransportWant& want);
+  ssize_t transportWrite(std::string_view data, TransportWant& want);
 
   RawChars buffer;                        // accumulated raw data
   RawChars bodyBuffer;                    // decoded body lifetime

--- a/aeronet/http/src/connection-state.cpp
+++ b/aeronet/http/src/connection-state.cpp
@@ -7,20 +7,24 @@
 
 namespace aeronet {
 
-ssize_t ConnectionState::transportRead(std::size_t chunkSize, bool& wantRead, bool& wantWrite) {
+ssize_t ConnectionState::transportRead(std::size_t chunkSize, TransportWant& want) {
   std::size_t oldSize = buffer.size();
 
   buffer.ensureAvailableCapacity(chunkSize);
   char* writePtr = buffer.data() + oldSize;
-  ssize_t bytesRead = transport->read(writePtr, chunkSize, wantRead, wantWrite);
+  ssize_t bytesRead = transport->read(writePtr, chunkSize, want);
   if (bytesRead > 0) {
     buffer.addSize(static_cast<std::size_t>(bytesRead));
   }
   return bytesRead;
 }
 
-ssize_t ConnectionState::transportWrite(std::string_view data, bool& wantRead, bool& wantWrite) const {
-  return transport->write(data, wantRead, wantWrite);
+ssize_t ConnectionState::transportWrite(std::string_view data, TransportWant& want) {
+  const auto res = transport->write(data, want);
+  if (!tlsEstablished && !transport->handshakePending()) {
+    tlsEstablished = true;
+  }
+  return res;
 }
 
 }  // namespace aeronet

--- a/aeronet/http/test/http-request_test.cpp
+++ b/aeronet/http/test/http-request_test.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "aeronet/http-constants.hpp"
 #include "aeronet/http-method.hpp"
 #include "aeronet/http-status-code.hpp"
 #include "aeronet/http-version.hpp"
@@ -24,10 +25,11 @@ std::string BuildRaw(std::string_view method, std::string_view target, std::stri
   std::string str;
   str.append(method).push_back(' ');
   str.append(target).push_back(' ');
-  str.append(version).append("\r\n");
-  str.append("Host: h\r\n");
+  str.append(version).append(http::CRLF);
+  str.append("Host: h");
+  str.append(http::CRLF);
   str.append(extraHeaders);
-  str.append("\r\n");
+  str.append(http::CRLF);
   return str;
 }
 }  // namespace
@@ -50,6 +52,11 @@ class HttpRequestTest : public ::testing::Test {
   HttpRequest req;
   ConnectionState cs;
 };
+
+TEST_F(HttpRequestTest, InvalidRequest) {
+  EXPECT_EQ(reqSet("GET / HTTP\r\n"), http::StatusCodeBadRequest);
+  EXPECT_EQ(reqSet("GET / HTTP1.1"), 0);
+}
 
 TEST_F(HttpRequestTest, ParseBasicPathAndVersion) {
   auto raw = BuildRaw("GET", "/abc", "HTTP/1.1");

--- a/aeronet/main/src/http-parser.cpp
+++ b/aeronet/main/src/http-parser.cpp
@@ -33,6 +33,7 @@ bool HttpServer::decodeFixedLengthBody(ConnectionMapIt cnxIt, HttpRequest& req, 
       static_cast<std::size_t>(req._flatHeaders.data() + req._flatHeaders.size() - state.buffer.data());
   if (!hasCL) {
     // No Content-Length and not chunked: treat as no body (common for GET/HEAD). Ready immediately.
+    // TODO: we should reject the query if body is non empty and ContentLength not specified
     if (state.buffer.size() >= headerEnd) {
       req._body = std::string_view{};
       consumedBytes = headerEnd;

--- a/aeronet/objects/include/aeronet/http-constants.hpp
+++ b/aeronet/objects/include/aeronet/http-constants.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string_view>
 
 #include "aeronet/http-status-code.hpp"
@@ -48,6 +49,10 @@ inline constexpr std::string_view Vary = "Vary";
 inline constexpr std::string_view AcceptEncoding = "Accept-Encoding";
 
 inline constexpr std::string_view HeaderSep = ": ";
+inline constexpr std::string_view CRLF = "\r\n";
+inline constexpr std::string_view DoubleCRLF = "\r\n\r\n";
+// 'GET / HTTP/1.1\r\n'
+inline constexpr std::size_t kHttpReqHeadersMinLen = GET.size() + 3UL + HTTP10Sv.size() + CRLF.size();
 
 // Compression
 inline constexpr std::string_view identity = "identity";
@@ -81,9 +86,6 @@ inline constexpr std::string_view ReasonHTTPVersionNotSupported = "HTTP Version 
 
 // Content type
 inline constexpr std::string_view ContentTypeTextPlain = "text/plain";
-
-inline constexpr std::string_view CRLF = "\r\n";
-inline constexpr std::string_view DoubleCRLF = "\r\n\r\n";
 
 // Return the canonical reason phrase for a subset of status codes we care about.
 // If an unmapped status is provided, returns an empty string_view, letting callers

--- a/aeronet/sys/include/transport.hpp
+++ b/aeronet/sys/include/transport.hpp
@@ -3,21 +3,33 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstddef>
+#include <cstdint>
 #include <string_view>
+#include <utility>
 
 namespace aeronet {
+
+// Indicates what the transport layer needs to proceed after a non-blocking I/O operation returns EAGAIN/WANT.
+enum class TransportWant : uint8_t {
+  None,       // No special action needed (operation completed or fatal error)
+  ReadReady,  // Need socket readable before operation can proceed (SSL_ERROR_WANT_READ)
+  WriteReady  // Need socket writable before operation can proceed (SSL_ERROR_WANT_WRITE)
+};
 
 // Base transport abstraction; allows transparent TLS or plain socket IO.
 class ITransport {
  public:
   virtual ~ITransport() = default;
 
-  // Non-blocking read. Returns bytes read (>0), 0 on orderly close, -1 on EAGAIN/WANT (caller inspects want flags).
-  virtual ssize_t read(char* buf, std::size_t len, bool& wantRead, bool& wantWrite) = 0;
+  // Non-blocking read. Returns bytes read (>0), 0 on orderly close, -1 on EAGAIN/WANT (caller inspects want).
+  // want: indicates whether socket needs to be readable or writable for operation to proceed.
+  virtual ssize_t read(char* buf, std::size_t len, TransportWant& want) = 0;
 
   // Non-blocking write. Returns bytes written (>0), 0 no progress (treat like EAGAIN), -1 fatal error.
-  virtual ssize_t write(std::string_view data, bool& wantRead, bool& wantWrite) = 0;
+  // want: indicates whether socket needs to be readable or writable for operation to proceed.
+  virtual ssize_t write(std::string_view data, TransportWant& want) = 0;
 
   [[nodiscard]] virtual bool handshakePending() const noexcept { return false; }
 };
@@ -27,14 +39,37 @@ class PlainTransport : public ITransport {
  public:
   explicit PlainTransport(int fd) : _fd(fd) {}
 
-  ssize_t read(char* buf, std::size_t len, bool& wantRead, bool& wantWrite) override {
-    wantRead = wantWrite = false;
+  ssize_t read(char* buf, std::size_t len, TransportWant& want) override {
+    want = TransportWant::None;
     return ::read(_fd, buf, len);
   }
 
-  ssize_t write(std::string_view data, bool& wantRead, bool& wantWrite) override {
-    wantRead = wantWrite = false;
-    return ::write(_fd, data.data(), data.size());
+  ssize_t write(std::string_view data, TransportWant& want) override {
+    want = TransportWant::None;
+
+    ssize_t total = 0;
+
+    while (std::cmp_less(total, data.size())) {
+      ssize_t res = ::write(_fd, data.data() + total, data.size() - static_cast<std::size_t>(total));
+
+      if (res > 0) {
+        total += res;
+      } else if (res == -1 && errno == EINTR) {
+        // Interrupted by signal, retry immediately
+        continue;
+      } else if (res == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        // Kernel send buffer full — caller should wait for writable event
+        want = TransportWant::WriteReady;
+        break;
+      } else {
+        // Fatal error (ECONNRESET, EPIPE, etc.)
+        return -1;
+      }
+    }
+
+    // Return how much we actually wrote.
+    // If total == 0 and wantWrite==true, treat it like EAGAIN/no progress.
+    return total;
   }
 
  private:

--- a/aeronet/test_support/include/aeronet/test_tls_client.hpp
+++ b/aeronet/test_support/include/aeronet/test_tls_client.hpp
@@ -67,6 +67,12 @@ class TlsClient {
 
   void loadClientCertKey(SSL_CTX* ctx);
 
+  // Wait for socket to be ready for reading or writing.
+  // events: POLLIN for readable, POLLOUT for writable
+  // Returns true if ready, false on timeout or error
+  template <typename Duration>
+  bool waitForSocketReady(short events, Duration timeout);
+
   uint16_t _port;
   Options _opts;
   bool _handshakeOk{false};

--- a/aeronet/test_support/src/test_tls_client.cpp
+++ b/aeronet/test_support/src/test_tls_client.cpp
@@ -1,13 +1,16 @@
 #include "aeronet/test_tls_client.hpp"
 
+#include <fcntl.h>
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/types.h>
 #include <openssl/x509.h>
+#include <poll.h>
 
 #include <cerrno>
+#include <chrono>
 #include <cstddef>
 #include <span>
 #include <stdexcept>
@@ -47,17 +50,32 @@ bool TlsClient::writeAll(std::string_view data) {
   }
   const char* cursor = data.data();
   auto remaining = data.size();
+
   while (remaining > 0) {
     int written = ::SSL_write(_ssl.get(), cursor, static_cast<int>(remaining));
-    if (written <= 0) {
-      int err = ::SSL_get_error(_ssl.get(), written);
-      if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
-        continue;
-      }
-      return false;
+    if (written > 0) {
+      cursor += written;
+      remaining -= static_cast<std::size_t>(written);
+      continue;
     }
-    cursor += written;
-    remaining -= static_cast<std::size_t>(written);
+
+    int err = ::SSL_get_error(_ssl.get(), written);
+    if (err == SSL_ERROR_WANT_READ) {
+      // SSL needs to read before it can write (e.g., renegotiation)
+      if (!waitForSocketReady(POLLIN, std::chrono::seconds(30))) {
+        return false;
+      }
+      continue;
+    }
+    if (err == SSL_ERROR_WANT_WRITE) {
+      // SSL needs socket to be writable
+      if (!waitForSocketReady(POLLOUT, std::chrono::seconds(30))) {
+        return false;
+      }
+      continue;
+    }
+    // Fatal error
+    return false;
   }
   return true;
 }
@@ -69,30 +87,80 @@ std::string TlsClient::readAll() {
   }
   static constexpr std::size_t kChunkSize = 4096;
   out.reserve(kChunkSize);
+
   for (;;) {
     const auto oldSize = out.size();
     if (out.capacity() < out.size() + kChunkSize) {
       // ensure exponential growth
       out.reserve(out.capacity() * 2UL);
     }
-    out.resize_and_overwrite(out.size() + kChunkSize, [this, oldSize](char* data, [[maybe_unused]] std::size_t newCap) {
-      int bytesRead = ::SSL_read(_ssl.get(), data + oldSize, kChunkSize);
-      if (bytesRead > 0) {
-        return oldSize + static_cast<std::size_t>(bytesRead);
-      }
-      return oldSize;
-    });
-    if (out.size() == oldSize) {
-      break;  // no new data read
+
+    int readRet = 0;
+    out.resize_and_overwrite(out.size() + kChunkSize,
+                             [this, oldSize, &readRet](char* data, [[maybe_unused]] std::size_t newCap) {
+                               readRet = ::SSL_read(_ssl.get(), data + oldSize, kChunkSize);
+                               if (readRet > 0) {
+                                 return oldSize + static_cast<std::size_t>(readRet);
+                               }
+                               return oldSize;
+                             });
+
+    if (readRet > 0) {
+      continue;  // Successfully read data, try to read more
     }
 
-    auto err = ::SSL_get_error(_ssl.get(), static_cast<int>(out.size() - oldSize));
-    if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+    // readRet <= 0: check SSL error
+    int err = ::SSL_get_error(_ssl.get(), readRet);
+    if (err == SSL_ERROR_ZERO_RETURN) {
+      // Clean SSL shutdown
+      break;
+    }
+    if (err == SSL_ERROR_WANT_READ) {
+      // SSL needs socket to be readable
+      if (!waitForSocketReady(POLLIN, std::chrono::seconds(30))) {
+        break;  // Timeout or error
+      }
       continue;
     }
-    break;  // fatal
+    if (err == SSL_ERROR_WANT_WRITE) {
+      // SSL needs to write before it can read (e.g., renegotiation)
+      if (!waitForSocketReady(POLLOUT, std::chrono::seconds(30))) {
+        break;  // Timeout or error
+      }
+      continue;
+    }
+    // Fatal error
+    break;
   }
   return out;
+}
+
+template <typename Duration>
+bool TlsClient::waitForSocketReady(short events, Duration timeout) {
+  int fd = ::SSL_get_fd(_ssl.get());
+  if (fd < 0) {
+    return false;
+  }
+
+  struct pollfd pfd;
+  pfd.fd = fd;
+  pfd.events = events;
+  pfd.revents = 0;
+
+  auto timeoutMs = std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count();
+  int ret = ::poll(&pfd, 1, static_cast<int>(timeoutMs));
+
+  if (ret < 0) {
+    // poll error
+    return false;
+  }
+  if (ret == 0) {
+    // Timeout
+    return false;
+  }
+
+  // Check if the requested event occurred
+  return (pfd.revents & events) != 0;
 }
 
 // Convenience: perform a GET request and read entire response.
@@ -134,27 +202,57 @@ void TlsClient::init() {
   }
   _cnx = aeronet::test::ClientConnection(_port);
 
+  // Set socket to non-blocking mode for poll()-based I/O
+  int fd = _cnx.fd();
+  int flags = ::fcntl(fd, F_GETFL, 0);
+  if (flags >= 0) {
+    ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+  }
+
   SSLUniquePtr localSsl(::SSL_new(localCtx.get()), ::SSL_free);
   if (!localSsl) {
     throw std::runtime_error("Unable to allocate SSL");
   }
-  ::SSL_set_fd(localSsl.get(), _cnx.fd());
-  int rc = ::SSL_connect(localSsl.get());
-  if (rc != 1) {
-    _ctx = std::move(localCtx);
-    _ssl = std::move(localSsl);
+  ::SSL_set_fd(localSsl.get(), fd);
+
+  // Move ownership first so we can use waitForSocketReady
+  _ctx = std::move(localCtx);
+  _ssl = std::move(localSsl);
+
+  // Perform SSL handshake with non-blocking socket
+  for (;;) {
+    int rc = ::SSL_connect(_ssl.get());
+    if (rc == 1) {
+      // Handshake successful
+      break;
+    }
+
+    int err = ::SSL_get_error(_ssl.get(), rc);
+    if (err == SSL_ERROR_WANT_READ) {
+      if (!waitForSocketReady(POLLIN, std::chrono::seconds(30))) {
+        _handshakeOk = false;
+        return;
+      }
+      continue;
+    }
+    if (err == SSL_ERROR_WANT_WRITE) {
+      if (!waitForSocketReady(POLLOUT, std::chrono::seconds(30))) {
+        _handshakeOk = false;
+        return;
+      }
+      continue;
+    }
+    // Fatal error
     _handshakeOk = false;
     return;
   }
   const unsigned char* proto = nullptr;
   unsigned int protoLen = 0;
-  ::SSL_get0_alpn_selected(localSsl.get(), &proto, &protoLen);
+  ::SSL_get0_alpn_selected(_ssl.get(), &proto, &protoLen);
   if (proto != nullptr && protoLen > 0) {
     _negotiatedAlpn.assign(reinterpret_cast<const char*>(proto), protoLen);
   }
   _handshakeOk = true;
-  _ctx = std::move(localCtx);
-  _ssl = std::move(localSsl);
 }
 
 void TlsClient::loadClientCertKey(SSL_CTX* ctx) {

--- a/aeronet/tls/include/tls-transport.hpp
+++ b/aeronet/tls/include/tls-transport.hpp
@@ -17,9 +17,9 @@ class TlsTransport : public ITransport {
 
   explicit TlsTransport(SslPtr sslPtr) : _ssl(std::move(sslPtr)) {}
 
-  ssize_t read(char* buf, std::size_t len, bool& wantRead, bool& wantWrite) override;
+  ssize_t read(char* buf, std::size_t len, TransportWant& want) override;
 
-  ssize_t write(std::string_view data, bool& wantRead, bool& wantWrite) override;
+  ssize_t write(std::string_view data, TransportWant& want) override;
 
   [[nodiscard]] bool handshakePending() const noexcept override;
 

--- a/benchmarks/frameworks/bench_util.hpp
+++ b/benchmarks/frameworks/bench_util.hpp
@@ -40,19 +40,19 @@ inline std::optional<std::size_t> requestBodySize(std::string_view method, std::
 
   // Extend deadline for benchmarks that request very large bodies over fresh TCP connections.
   // Keep tests / CI responsive while avoiding spurious timeouts for multi-megabyte responses.
-  constexpr auto kGlobalDeadline = std::chrono::seconds(15);
+  constexpr auto kGlobalDeadline = std::chrono::seconds(30);
   const auto deadline = std::chrono::steady_clock::now() + kGlobalDeadline;
   aeronet::RawChars buffer;
   std::size_t contentLength = 0;
   bool haveCL = false;
   // 1. Read headers
   while (std::chrono::steady_clock::now() < deadline) {
-    constexpr std::size_t kChunk = static_cast<std::size_t>(64) * 1024ULL;
+    constexpr std::size_t kChunkSize = static_cast<std::size_t>(64) * 1024ULL;
     std::size_t oldSize = buffer.size();
     std::size_t written = 0;
-    buffer.resize_and_overwrite(oldSize + kChunk, [&](char* data, [[maybe_unused]] std::size_t newCap) {
+    buffer.resize_and_overwrite(oldSize + kChunkSize, [&](char* data, [[maybe_unused]] std::size_t newCap) {
       for (;;) {
-        ssize_t recvBytes = ::recv(fd, data + oldSize, kChunk, 0);  // blocking
+        ssize_t recvBytes = ::recv(fd, data + oldSize, kChunkSize, 0);  // blocking
         if (recvBytes > 0) {
           written = static_cast<std::size_t>(recvBytes);
           return oldSize + written;

--- a/tests/http_additional_test.cpp
+++ b/tests/http_additional_test.cpp
@@ -79,7 +79,7 @@ TEST(HttpPipeline, SecondMalformedAfterSuccess) {
   });
   aeronet::test::ClientConnection clientConnection(ts.port());
   int fd = clientConnection.fd();
-  std::string piped = "GET /good HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\nBADSECOND\r\n\r\n";
+  std::string piped = "GET /good HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\nBADSECONDREQUEST\r\n\r\n";
   ASSERT_TRUE(aeronet::test::sendAll(fd, piped));
   std::string resp = aeronet::test::recvUntilClosed(fd);
   ASSERT_NE(std::string::npos, resp.find("OK"));
@@ -123,4 +123,86 @@ TEST(HttpContentLength, GlobalHeaders) {
   EXPECT_NE(std::string::npos, resp.find("\r\nX-Global: gvalue"));
   EXPECT_NE(std::string::npos, resp.find("\r\nX-Another: anothervalue"));
   EXPECT_NE(std::string::npos, resp.find("\r\nX-Custom: original"));
+}
+
+TEST(HttpBasic, LargePayload) {
+  std::string largeBody(1 << 24, 'a');
+  aeronet::HttpServerConfig cfg;
+  cfg.maxOutboundBufferBytes = largeBody.size() + 512;  // +512 for headers
+  aeronet::test::TestServer ts(cfg);
+  ts.server.router().setDefault([&largeBody](const aeronet::HttpRequest&) {
+    aeronet::HttpResponse respObj;
+    respObj.body(largeBody);
+    return respObj;
+  });
+  aeronet::test::ClientConnection clientConnection(ts.port());
+  int fd = clientConnection.fd();
+  std::string req = "GET /good HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+  ASSERT_TRUE(aeronet::test::sendAll(fd, req));
+  std::string resp = aeronet::test::recvUntilClosed(fd);
+  EXPECT_TRUE(resp.contains("HTTP/1.1 200"));
+  EXPECT_TRUE(resp.contains(largeBody));
+}
+
+TEST(HttpBasic, ManyHeadersRequest) {
+  // Test handling a request with thousands of headers
+  aeronet::HttpServerConfig cfg;
+  cfg.withMaxHeaderBytes(128UL * 1024UL);
+  aeronet::test::TestServer ts(cfg);
+  ts.server.router().setDefault([](const aeronet::HttpRequest& req) {
+    int headerCount = 0;
+    for (const auto& [key, value] : req.headers()) {
+      if (key.starts_with("X-Custom-")) {
+        ++headerCount;
+      }
+    }
+    aeronet::HttpResponse respObj;
+    respObj.body("Received " + std::to_string(headerCount) + " custom headers");
+    return respObj;
+  });
+  aeronet::test::ClientConnection clientConnection(ts.port());
+  int fd = clientConnection.fd();
+
+  // Build request with many custom headers
+  static constexpr int kNbHeaders = 3000;
+  std::string req = "GET /test HTTP/1.1\r\nHost: localhost\r\n";
+  for (int headerPos = 0; headerPos < kNbHeaders; ++headerPos) {
+    req += "X-Custom-" + std::to_string(headerPos) + ": value" + std::to_string(headerPos) + "\r\n";
+  }
+  req += "Content-Length: 0\r\nConnection: close\r\n\r\n";
+
+  ASSERT_TRUE(aeronet::test::sendAll(fd, req));
+  std::string resp = aeronet::test::recvUntilClosed(fd);
+  EXPECT_TRUE(resp.contains("HTTP/1.1 200"));
+  EXPECT_TRUE(resp.contains("Received " + std::to_string(kNbHeaders) + " custom headers"));
+}
+
+TEST(HttpBasic, ManyHeadersResponse) {
+  // Test generating a response with thousands of headers
+  aeronet::test::TestServer ts(aeronet::HttpServerConfig{});
+  ts.server.router().setDefault([](const aeronet::HttpRequest&) {
+    aeronet::HttpResponse respObj;
+    // Add 3000 custom headers to response
+    for (int i = 0; i < 3000; ++i) {
+      respObj.addCustomHeader("X-Response-" + std::to_string(i), "value" + std::to_string(i));
+    }
+    respObj.body("Response with many headers");
+    return respObj;
+  });
+  aeronet::test::ClientConnection clientConnection(ts.port());
+  int fd = clientConnection.fd();
+
+  std::string req = "GET /test HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+  ASSERT_TRUE(aeronet::test::sendAll(fd, req));
+  std::string resp = aeronet::test::recvUntilClosed(fd);
+  EXPECT_TRUE(resp.contains("HTTP/1.1 200"));
+  EXPECT_TRUE(resp.contains("Response with many headers"));
+
+  // Verify some of the custom headers are present
+  EXPECT_TRUE(resp.contains("X-Response-0: value0"));
+  EXPECT_TRUE(resp.contains("X-Response-500: value500"));
+  EXPECT_TRUE(resp.contains("X-Response-999: value999"));
+  EXPECT_TRUE(resp.contains("X-Response-1499: value1499"));
+  EXPECT_TRUE(resp.contains("X-Response-1999: value1999"));
+  EXPECT_TRUE(resp.contains("X-Response-2999: value2999"));
 }

--- a/tests/http_errors_test.cpp
+++ b/tests/http_errors_test.cpp
@@ -31,7 +31,7 @@ TEST_P(HttpErrorParamTest, EmitsExpectedStatus) {
 
 INSTANTIATE_TEST_SUITE_P(
     HttpErrors, HttpErrorParamTest,
-    ::testing::Values(ErrorCase{"MalformedRequestLine", "GETONLY\r\n\r\n", "400"},
+    ::testing::Values(ErrorCase{"MalformedRequestLine", "GETONLYNOPATH\r\n\r\n", "400"},
                       ErrorCase{"VersionNotSupported", "GET /test HTTP/2.0\r\nHost: x\r\n\r\n", "505"},
                       ErrorCase{"UnsupportedTransferEncoding",
                                 "POST /u HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: gzip\r\nConnection: close\r\n\r\n",

--- a/tests/http_tls_basic_test.cpp
+++ b/tests/http_tls_basic_test.cpp
@@ -10,20 +10,32 @@
 
 TEST(HttpTlsBasic, HandshakeAndSimpleGet) {
   // Prepare config with in-memory self-signed cert/key
-  std::string raw;
-  {
-    aeronet::test::TlsTestServer ts;  // ephemeral TLS server
-    ts.setDefault([](const aeronet::HttpRequest& req) {
-      return aeronet::HttpResponse(200, "OK")
-          .contentType(aeronet::http::ContentTypeTextPlain)
-          .body(std::string("TLS OK ") + std::string(req.path()));
-    });
-    aeronet::test::TlsClient client(ts.port());
-    raw = client.get("/hello", {{"X-Test", "tls"}});
-    ts.stop();
-  }
-  // No explicit cleanup required: helper frees all allocated OpenSSL objects.
+  aeronet::test::TlsTestServer ts;  // ephemeral TLS server
+  ts.setDefault([](const aeronet::HttpRequest& req) {
+    return aeronet::HttpResponse(200, "OK")
+        .contentType(aeronet::http::ContentTypeTextPlain)
+        .body(std::string("TLS OK ") + std::string(req.path()));
+  });
+  aeronet::test::TlsClient client(ts.port());
+  auto raw = client.get("/hello", {{"X-Test", "tls"}});
   ASSERT_FALSE(raw.empty());
   ASSERT_NE(std::string::npos, raw.find("HTTP/1.1 200"));
   ASSERT_NE(std::string::npos, raw.find("TLS OK /hello"));
+}
+
+TEST(HttpTlsBasic, LargePayload) {
+  std::string largeBody(1 << 24, 'a');
+  // Prepare config with in-memory self-signed cert/key
+  aeronet::test::TlsTestServer ts({"http/1.1"}, [&](aeronet::HttpServerConfig& cfg) {
+    cfg.maxOutboundBufferBytes = largeBody.size() + 512;  // +512 for headers
+    cfg.keepAliveTimeout = std::chrono::years(1);
+  });
+  ts.setDefault([&largeBody]([[maybe_unused]] const aeronet::HttpRequest& req) {
+    return aeronet::HttpResponse(200, "OK").contentType(aeronet::http::ContentTypeTextPlain).body(largeBody);
+  });
+  aeronet::test::TlsClient client(ts.port());
+  auto raw = client.get("/hello", {{"X-Test", "tls"}});
+  ASSERT_FALSE(raw.empty());
+  EXPECT_TRUE(raw.contains("HTTP/1.1 200"));
+  EXPECT_TRUE(raw.contains(largeBody));
 }


### PR DESCRIPTION
In TLS, we need to send the exact same buffer to SSL_write in case of retry (same pointer).