### PR TITLE
feat: simplify setting of content type header in response

### DIFF
--- a/aeronet/http/test/cors-policy_test.cpp
+++ b/aeronet/http/test/cors-policy_test.cpp
@@ -64,7 +64,7 @@ TEST_F(CorsPolicyHarness, ApplyAllowListMirrorsOriginAndAddsCredentials) {
   ASSERT_EQ(status, http::StatusCodeOK);
 
   HttpResponse response;
-  response.addCustomHeader(http::Vary, "Accept-Encoding");
+  response.addHeader(http::Vary, "Accept-Encoding");
 
   const auto applyStatus = policy.applyToResponse(request, response);
   EXPECT_EQ(applyStatus, CorsPolicy::ApplyStatus::Applied);
@@ -185,7 +185,7 @@ TEST_F(CorsPolicyHarness, ExposeHeadersAndVaryMerging) {
   ASSERT_EQ(status, http::StatusCodeOK);
 
   HttpResponse response;
-  response.addCustomHeader(http::Vary, "Accept-Encoding");
+  response.addHeader(http::Vary, "Accept-Encoding");
 
   const auto applyStatus = policy.applyToResponse(request, response);
   EXPECT_EQ(applyStatus, CorsPolicy::ApplyStatus::Applied);

--- a/aeronet/objects/include/aeronet/http-constants.hpp
+++ b/aeronet/objects/include/aeronet/http-constants.hpp
@@ -129,6 +129,7 @@ inline constexpr std::string_view ContentTypeTextPlain = "text/plain";
 inline constexpr std::string_view ContentTypeTextHtml = "text/html";
 inline constexpr std::string_view ContentTypeApplicationJson = "application/json";
 inline constexpr std::string_view ContentTypeApplicationOctetStream = "application/octet-stream";
+inline constexpr std::string_view ContentTypeMessageHttp = "message/http";
 
 // Return the canonical reason phrase for a subset of status codes we care about.
 // If an unmapped status is provided, returns an empty string_view, letting callers

--- a/aeronet/objects/include/aeronet/mime-mappings.hpp
+++ b/aeronet/objects/include/aeronet/mime-mappings.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace aeronet {
+
+struct MIMEMapping {
+  std::string_view extension;
+  std::string_view mimeType;
+};
+
+using MIMETypeIdx = uint8_t;
+
+inline constexpr MIMETypeIdx kUnknownMIMEMappingIdx = static_cast<MIMETypeIdx>(~0);
+
+inline constexpr MIMEMapping kMIMEMappings[] = {
+    {"7z", "application/x-7z-compressed"},
+    {"aac", "audio/aac"},
+    {"apng", "image/apng"},
+    {"avi", "video/x-msvideo"},
+    {"avif", "image/avif"},
+    {"bmp", "image/bmp"},
+    {"c", "text/x-csrc"},
+    {"cc", "text/x-c++src"},
+    {"cpp", "text/x-c++src"},
+    {"css", "text/css"},
+    {"csv", "text/csv"},
+    {"doc", "application/msword"},
+    {"docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+    {"exe", "application/vnd.microsoft.portable-executable"},
+    {"flac", "audio/flac"},
+    {"gif", "image/gif"},
+    {"gz", "application/gzip"},
+    {"h", "text/x-chdr"},
+    {"hpp", "text/x-c++hdr"},
+    {"html", "text/html"},
+    {"htm", "text/html"},
+    {"ico", "image/x-icon"},
+    {"jfif", "image/jpeg"},
+    {"jpg", "image/jpeg"},
+    {"jpeg", "image/jpeg"},
+    // Per IETF RFC 9239, `text/javascript` is the recommended media type for
+    // JavaScript source; `application/javascript` is now considered obsolete.
+    {"js", "text/javascript"},
+    {"json", "application/json"},
+    {"map", "application/json"},
+    {"m4a", "audio/mp4"},
+    {"m4v", "video/x-m4v"},
+    {"md", "text/markdown"},
+    {"mjs", "text/javascript"},
+    {"mov", "video/quicktime"},
+    {"mp3", "audio/mpeg"},
+    {"mp4", "video/mp4"},
+    {"mpeg", "video/mpeg"},
+    {"mpg", "video/mpeg"},
+    {"oga", "audio/ogg"},
+    {"ogg", "audio/ogg"},
+    {"otf", "font/otf"},
+    {"pdf", "application/pdf"},
+    {"pjp", "image/jpeg"},
+    {"pjpeg", "image/jpeg"},
+    {"png", "image/png"},
+    {"ppt", "application/vnd.ms-powerpoint"},
+    {"pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"},
+    {"ps1", "text/plain"},
+    {"py", "text/x-python"},
+    {"rar", "application/vnd.rar"},
+    {"rss", "application/rss+xml"},
+    {"sh", "application/x-sh"},
+    {"svg", "image/svg+xml"},
+    {"tar", "application/x-tar"},
+    {"tar.gz", "application/gzip"},
+    {"tgz", "application/gzip"},
+    {"tif", "image/tiff"},
+    {"tiff", "image/tiff"},
+    {"ttf", "font/ttf"},
+    {"txt", "text/plain"},
+    {"wasm", "application/wasm"},
+    {"webm", "video/webm"},
+    {"webp", "image/webp"},
+    {"woff", "font/woff"},
+    {"woff2", "font/woff2"},
+    {"xls", "application/vnd.ms-excel"},
+    {"xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+    {"xml", "application/xml"},
+    {"zip", "application/zip"},
+};
+}  // namespace aeronet

--- a/aeronet/sys/CMakeLists.txt
+++ b/aeronet/sys/CMakeLists.txt
@@ -27,3 +27,11 @@ add_unit_test(
     LIBRARIES
     aeronet_sys
 )
+
+add_unit_test(
+    file_test
+    test/file_test.cpp
+    LIBRARIES
+    aeronet_sys
+    aeronet_test_support
+)

--- a/aeronet/sys/include/file.hpp
+++ b/aeronet/sys/include/file.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <string_view>
 
+#include "aeronet/mime-mappings.hpp"
 #include "base-fd.hpp"
 
 namespace aeronet {
@@ -21,8 +22,14 @@ class File {
   // On failure, operator bool() returns false.
   explicit File(const std::string& path, OpenMode mode = OpenMode::ReadOnly) : File(path.c_str(), mode) {}
 
-  // Path overloads accepting string_view or C-string for convenience.
+  // Open a file by path. Throws on error.
+  // On success, the returned File owns the underlying descriptor and will close it on destruction.
+  // On failure, operator bool() returns false.
   explicit File(std::string_view path, OpenMode mode = OpenMode::ReadOnly);
+
+  // Open a file by path (must be null-terminated). Throws on error.
+  // On success, the returned File owns the underlying descriptor and will close it on destruction.
+  // On failure, operator bool() returns false.
   explicit File(const char* path, OpenMode mode = OpenMode::ReadOnly);
 
   // Returns true when the File currently holds an opened descriptor.
@@ -34,6 +41,10 @@ class File {
   // Load the entire file content into a string. Throws on error.
   [[nodiscard]] std::string loadAllContent() const;
 
+  // Returns the probable content type based on the file extension.
+  // If not found, return 'application/octet-stream'.
+  [[nodiscard]] std::string_view detectedContentType() const;
+
  private:
   friend struct ConnectionState;
 
@@ -43,6 +54,7 @@ class File {
   [[nodiscard]] int fd() const noexcept { return _fd.fd(); }
 
   BaseFd _fd;
+  MIMETypeIdx _mimeMappingIdx = kUnknownMIMEMappingIdx;
 };
 
 }  // namespace aeronet

--- a/aeronet/sys/test/file_test.cpp
+++ b/aeronet/sys/test/file_test.cpp
@@ -1,0 +1,75 @@
+#include "file.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <ios>
+
+#include "aeronet/temp-file.hpp"
+
+using namespace aeronet;
+
+using test::ScopedTempDir;
+using test::ScopedTempFile;
+
+TEST(FileTest, DefaultConstructedIsFalse) {
+  File fileObj;
+  EXPECT_FALSE(static_cast<bool>(fileObj));
+}
+
+TEST(FileTest, SizeAndLoadAllContent) {
+  ScopedTempDir tmpDir("aeronet-file-test");
+  ScopedTempFile tmp(tmpDir, "hello world\n");
+  File fileObj(tmp.filePath().string(), File::OpenMode::ReadOnly);
+  ASSERT_TRUE(static_cast<bool>(fileObj));
+  EXPECT_EQ(fileObj.size(), std::string("hello world\n").size());
+  const auto content = fileObj.loadAllContent();
+  EXPECT_EQ(content, "hello world\n");
+}
+
+TEST(FileTest, DetectedContentTypeKnownExtension) {
+  ScopedTempDir mdDir("aeronet-file-md");
+  const auto mdPath = mdDir.dirPath() / "sample.md";
+  std::ofstream ofs(mdPath);
+  ofs << "# title\n";
+  ofs.close();
+  File fileObj(mdPath.string(), File::OpenMode::ReadOnly);
+  ASSERT_TRUE(static_cast<bool>(fileObj));
+  EXPECT_EQ(fileObj.detectedContentType(), "text/markdown");
+}
+
+TEST(FileTest, DetectedContentTypeMultiDot) {
+  ScopedTempDir tgzDir("aeronet-file-tgz");
+  const auto tgzPath = tgzDir.dirPath() / "archive.tar.gz";
+  std::ofstream ofs(tgzPath);
+  ofs << "data";
+  ofs.close();
+  File fileObj(tgzPath.string(), File::OpenMode::ReadOnly);
+  ASSERT_TRUE(static_cast<bool>(fileObj));
+  // We expect tar.gz to resolve to application/gzip per the mappings
+  EXPECT_EQ(fileObj.detectedContentType(), "application/gzip");
+}
+
+TEST(FileTest, DetectedContentTypeUnknownFallsBackToOctet) {
+  ScopedTempDir unkDir("aeronet-file-unk");
+  const auto unkPath = unkDir.dirPath() / "file.unknownext";
+  std::ofstream ofs2(unkPath, std::ios::binary);
+  ofs2.write("\0\1\2", 3);
+  ofs2.close();
+  File fileObj(unkPath.string(), File::OpenMode::ReadOnly);
+  ASSERT_TRUE(static_cast<bool>(fileObj));
+  EXPECT_EQ(fileObj.detectedContentType(), "application/octet-stream");
+}
+
+TEST(FileTest, DetectedContentTypeCaseSensitiveUppercaseFallsBack) {
+  ScopedTempDir upperDir("aeronet-file-upper");
+  const auto upperPath = upperDir.dirPath() / "UPPER.TXT";
+  std::ofstream ofs3(upperPath);
+  ofs3 << "hi";
+  ofs3.close();
+  File fileObj(upperPath.string(), File::OpenMode::ReadOnly);
+  ASSERT_TRUE(static_cast<bool>(fileObj));
+  // Current implementation does case-sensitive extension matching, so uppercase extension falls back
+  EXPECT_EQ(fileObj.detectedContentType(), "application/octet-stream");
+}

--- a/aeronet/tech/test/raw-bytes_test.cpp
+++ b/aeronet/tech/test/raw-bytes_test.cpp
@@ -4,7 +4,9 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
+#include <new>
 #include <span>
 #include <string>
 #include <string_view>

--- a/aeronet/tech/test/static-concatenated-strings_test.cpp
+++ b/aeronet/tech/test/static-concatenated-strings_test.cpp
@@ -5,9 +5,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <stdexcept>
 #include <string>
 #include <string_view>
-#include <utility>
 
 using namespace aeronet;
 
@@ -44,20 +44,20 @@ TEST(ConcatenatedStrings, LongStringsAreHandled) {
 
 TEST(ConcatenatedStrings, GuardAgainstOverflowConstruction) {
   using T = StaticConcatenatedStrings<3, uint8_t>;
-  std::string a(128, 'A');
-  std::string b(100, 'B');
-  std::string c(24, 'C');
+  std::string aa(128, 'A');
+  std::string bb(100, 'B');
+  std::string cc(24, 'C');
 
-  EXPECT_NO_THROW((T({a, b, c})));
-  EXPECT_THROW((T({a, b, b})), std::length_error);
+  EXPECT_NO_THROW((T({aa, bb, cc})));
+  EXPECT_THROW((T({aa, bb, bb})), std::length_error);
 }
 
 TEST(ConcatenatedStrings, GuardAgainstOverflowSet) {
   StaticConcatenatedStrings<3, uint8_t> tooSmall({"", "", ""});
-  std::string a(128, 'A');
-  std::string b(128, 'B');
-  tooSmall.set(0, a);
-  EXPECT_THROW(tooSmall.set(1, b), std::length_error);
+  std::string aa(128, 'A');
+  std::string bb(128, 'B');
+  tooSmall.set(0, aa);
+  EXPECT_THROW(tooSmall.set(1, bb), std::length_error);
 }
 
 TEST(ConcatenatedStrings, CopyAndAssign) {

--- a/aeronet/test_support/src/test_util.cpp
+++ b/aeronet/test_support/src/test_util.cpp
@@ -26,6 +26,7 @@
 
 #include "aeronet/http-constants.hpp"
 #include "aeronet/http-status-code.hpp"
+#include "base-fd.hpp"
 #include "errno_throw.hpp"
 #include "log.hpp"
 #include "raw-chars.hpp"

--- a/benchmarks/frameworks/bench_frameworks_basic.cpp
+++ b/benchmarks/frameworks/bench_frameworks_basic.cpp
@@ -91,7 +91,7 @@ struct AeronetServerRunner {
         throw std::runtime_error("Should have found number of headers");
       }
       for (size_t headerPos = 0; headerPos < headerCount; ++headerPos) {
-        resp.addCustomHeader(g_stringPool.next(), g_stringPool.next());
+        resp.addHeader(g_stringPool.next(), g_stringPool.next());
       }
       resp.body(std::to_string(headerCount));
       return resp;
@@ -609,7 +609,7 @@ void AeronetResponseBuild(benchmark::State &state) {
       auto headerVal = g_stringPool.next();
       bytesSynthesized += headerKey.size() + headerVal.size();
 
-      resp.addCustomHeader(headerKey, headerVal);
+      resp.addHeader(headerKey, headerVal);
     }
     resp.body(std::move(body));
     // Finalization occurs when serialized for send; emulate by calling body() + reserved header injection via copy

--- a/examples/async.cpp
+++ b/examples/async.cpp
@@ -7,9 +7,8 @@ using namespace aeronet;
 
 int main() {
   AsyncHttpServer async(HttpServerConfig{});
-  async.router().setDefault([](const HttpRequest&) {
-    return HttpResponse(200, "OK").contentType(http::ContentTypeTextPlain).body("hello from async server\n");
-  });
+  async.router().setDefault(
+      [](const HttpRequest&) { return HttpResponse(200, "OK").body("hello from async server\n"); });
   async.start();
   std::cout << "Async server listening on port " << async.port() << '\n';
   std::cout << "Sleeping for 2 seconds while serving..." << '\n';

--- a/examples/multi.cpp
+++ b/examples/multi.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <thread>
 
-#include "aeronet/http-constants.hpp"
 #include "log.hpp"
 
 namespace {
@@ -29,9 +28,8 @@ int main(int argc, char** argv) {
   cfg.withPort(port).withReusePort(true);
   aeronet::MultiHttpServer multi(cfg, static_cast<uint32_t>(threads));
   multi.router().setDefault([](const aeronet::HttpRequest& req) {
-    return aeronet::HttpResponse(200, "OK")
-        .contentType(aeronet::http::ContentTypeTextPlain)
-        .body(std::string("multi reactor response ") + std::string(req.path()) + '\n');
+    return aeronet::HttpResponse(200, "OK").body(std::string("multi reactor response ") + std::string(req.path()) +
+                                                 '\n');
   });
   multi.start();
   aeronet::log::info("Listening on {} with {} reactors (SO_REUSEPORT). Press Ctrl+C to stop.", multi.port(), threads);

--- a/examples/sendfile.cpp
+++ b/examples/sendfile.cpp
@@ -37,15 +37,14 @@ int main(int argc, char** argv) {
 
   // Fixed response (HttpResponse::file) on /static
   srv.router().setPath(aeronet::http::Method::GET, "/static", [path = path](const aeronet::HttpRequest& /*req*/) {
-    return aeronet::HttpResponse(aeronet::http::StatusCodeOK).contentType("text/plain").file(aeronet::File(path));
+    return aeronet::HttpResponse(aeronet::http::StatusCodeOK).file(aeronet::File(path));
   });
 
   // Streaming response using HttpResponseWriter::file on /stream
   srv.router().setPath(aeronet::http::Method::GET, "/stream",
                        [path = path](const aeronet::HttpRequest& /*req*/, aeronet::HttpResponseWriter& writer) {
                          writer.status(aeronet::http::StatusCodeOK);
-                         writer.contentType("text/plain");
-                         writer.file(aeronet::File(path));
+                         writer.file(aeronet::File(path), "text/plain");
                          writer.end();
                        });
 

--- a/tests/async-http-server_test.cpp
+++ b/tests/async-http-server_test.cpp
@@ -9,7 +9,6 @@
 #include <string_view>
 #include <thread>
 
-#include "aeronet/http-constants.hpp"
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
@@ -46,9 +45,8 @@ bool WaitForServerRunning(const AsyncHttpServer &server, std::chrono::millisecon
 
 TEST(AsyncHttpServer, BasicStartStopAndRequest) {
   AsyncHttpServer async(HttpServerConfig{});
-  async.router().setDefault([]([[maybe_unused]] const HttpRequest &req) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("hello-async");
-  });
+  async.router().setDefault(
+      []([[maybe_unused]] const HttpRequest &req) { return HttpResponse(http::StatusCodeOK).body("hello-async"); });
   async.start();
   // Allow a short grace period.
   std::this_thread::sleep_for(20ms);
@@ -83,9 +81,8 @@ TEST(AsyncHttpServer, Restart) {
   AsyncHttpServer async(HttpServerConfig{});
   auto port = async.port();
   EXPECT_GT(port, 0);
-  async.router().setDefault([]([[maybe_unused]] const HttpRequest &req) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("hello-async1");
-  });
+  async.router().setDefault(
+      []([[maybe_unused]] const HttpRequest &req) { return HttpResponse(http::StatusCodeOK).body("hello-async1"); });
   async.start();
   // Allow a short grace period.
   std::this_thread::sleep_for(20ms);
@@ -100,9 +97,8 @@ TEST(AsyncHttpServer, Restart) {
 
   async.stop();
   // change router
-  async.router().setDefault([]([[maybe_unused]] const HttpRequest &req) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("hello-async2");
-  });
+  async.router().setDefault(
+      []([[maybe_unused]] const HttpRequest &req) { return HttpResponse(http::StatusCodeOK).body("hello-async2"); });
   async.start();
 
   resp = test::requestOrThrow(port, opt);

--- a/tests/http-additional_test.cpp
+++ b/tests/http-additional_test.cpp
@@ -14,6 +14,7 @@
 #include "aeronet/http-server.hpp"
 #include "aeronet/test_server_fixture.hpp"
 #include "aeronet/test_util.hpp"
+#include "raw-chars.hpp"
 #include "stringconv.hpp"
 
 using namespace std::chrono_literals;
@@ -118,7 +119,7 @@ TEST(HttpContentLength, GlobalHeaders) {
   test::TestServer ts(cfg);
   ts.server.router().setDefault([](const HttpRequest&) {
     HttpResponse respObj;
-    respObj.customHeader("X-Custom", "original");
+    respObj.header("X-Custom", "original");
     respObj.body("R");
     return respObj;
   });
@@ -197,7 +198,7 @@ TEST(HttpBasic, ManyHeadersResponse) {
     HttpResponse respObj;
     // Add 3000 custom headers to response
     for (int i = 0; i < 3000; ++i) {
-      respObj.addCustomHeader("X-Response-" + std::to_string(i), "value" + std::to_string(i));
+      respObj.addHeader("X-Response-" + std::to_string(i), "value" + std::to_string(i));
     }
     respObj.body("Response with many headers");
     return respObj;
@@ -355,7 +356,7 @@ TEST(HttpExpectation, HandlerFinalResponseSkipsBody) {
     if (token == "auth-check") {
       res.kind = HttpServer::ExpectationResultKind::FinalResponse;
       HttpResponse hr(403, "Forbidden");
-      hr.contentType("text/plain").body("nope");
+      hr.body("nope");
       res.finalResponse = std::move(hr);
       return res;
     }

--- a/tests/http-compression_test.cpp
+++ b/tests/http-compression_test.cpp
@@ -48,7 +48,7 @@ TEST(HttpCompressionBrotliBuffered, BrAppliedWhenEligible) {
   std::string payload(400, 'B');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse respObj;
-    respObj.customHeader("Content-Type", "text/plain");
+    respObj.header("Content-Type", "text/plain");
     respObj.body(payload);
     return respObj;
   });
@@ -73,8 +73,8 @@ TEST(HttpCompressionBrotliBuffered, UserContentEncodingIdentityDisablesCompressi
   std::string payload(128, 'U');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse respObj;
-    respObj.customHeader("Content-Type", "text/plain");
-    respObj.customHeader("Content-Encoding", "identity");
+    respObj.header("Content-Type", "text/plain");
+    respObj.header("Content-Encoding", "identity");
     respObj.body(payload);
     return respObj;
   });
@@ -215,7 +215,7 @@ TEST(HttpCompressionBrotliStreaming, UserProvidedIdentityPreventsActivation) {
   std::string payload(512, 'Y');
   ts.server.router().setDefault([payload]([[maybe_unused]] const HttpRequest &req, HttpResponseWriter &writer) {
     writer.status(http::StatusCodeOK);
-    writer.customHeader("Content-Encoding", "identity");
+    writer.header("Content-Encoding", "identity");
     writer.writeBody(payload);
     writer.end();
   });
@@ -288,8 +288,8 @@ TEST(HttpCompressionBuffered, UserContentEncodingIdentityDisablesCompression) {
   std::string payload(128, 'B');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
-    resp.customHeader("Content-Encoding", "identity");  // explicit suppression
+    resp.header("Content-Type", "text/plain");
+    resp.header("Content-Encoding", "identity");  // explicit suppression
     resp.body(payload);
     return resp;
   });
@@ -315,7 +315,7 @@ TEST(HttpCompressionBuffered, BelowThresholdNotCompressed) {
   std::string smallPayload(32, 'C');
   ts.server.router().setDefault([smallPayload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
+    resp.header("Content-Type", "text/plain");
     resp.body(smallPayload);
     return resp;
   });
@@ -338,7 +338,7 @@ TEST(HttpCompressionBuffered, NoAcceptEncodingHeaderStillCompressesDefault) {
   std::string payload(128, 'D');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
+    resp.header("Content-Type", "text/plain");
     resp.body(payload);
     return resp;
   });
@@ -364,7 +364,7 @@ TEST(HttpCompressionBuffered, IdentityForbiddenNoAlternativesReturns406) {
   std::string payload(64, 'Q');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
+    resp.header("Content-Type", "text/plain");
     resp.body(payload);
     return resp;
   });
@@ -387,7 +387,7 @@ TEST(HttpCompressionBuffered, IdentityForbiddenButGzipAvailableUsesGzip) {
   std::string payload(128, 'Z');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
+    resp.header("Content-Type", "text/plain");
     resp.body(payload);
     return resp;
   });
@@ -412,7 +412,7 @@ TEST(HttpCompressionBuffered, UnsupportedEncodingDoesNotApplyGzip) {
   std::string payload(200, 'E');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
+    resp.header("Content-Type", "text/plain");
     resp.body(payload);
     return resp;
   });
@@ -437,7 +437,7 @@ TEST(HttpCompressionBuffered, DeflateAppliedWhenPreferredAndAccepted) {
   std::string largePayload(300, 'F');
   ts.server.router().setDefault([largePayload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
+    resp.header("Content-Type", "text/plain");
     resp.body(largePayload);
     return resp;
   });
@@ -464,7 +464,7 @@ TEST(HttpCompressionBuffered, GzipChosenWhenHigherPreference) {
   std::string payload(256, 'G');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
+    resp.header("Content-Type", "text/plain");
     resp.body(payload);
     return resp;
   });
@@ -490,7 +490,7 @@ TEST(HttpCompressionBuffered, QValuesAffectSelection) {
   std::string payload(180, 'H');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
+    resp.header("Content-Type", "text/plain");
     resp.body(payload);
     return resp;
   });
@@ -514,7 +514,7 @@ TEST(HttpCompressionBuffered, IdentityFallbackIfDeflateNotRequested) {
   std::string payload(256, 'I');
   ts.server.router().setDefault([payload](const HttpRequest &) {
     HttpResponse resp;
-    resp.customHeader("Content-Type", "text/plain");
+    resp.header("Content-Type", "text/plain");
     resp.body(payload);
     return resp;
   });
@@ -622,7 +622,7 @@ TEST(HttpCompressionStreaming, UserProvidedContentEncodingIdentityPreventsActiva
   ts.server.router().setDefault([big](const HttpRequest &, HttpResponseWriter &writer) {
     writer.status(http::StatusCodeOK);
     writer.contentType("text/plain");
-    writer.customHeader("Content-Encoding", "identity");  // explicit suppression
+    writer.header("Content-Encoding", "identity");  // explicit suppression
     writer.writeBody(big.substr(0, 50));
     writer.writeBody(big.substr(50));
     writer.end();
@@ -691,7 +691,7 @@ TEST(HttpCompressionZstdBuffered, ZstdAppliedWhenEligible) {
     std::string payload(400, 'A');
     ts.server.router().setDefault([payload](const HttpRequest &) {
       HttpResponse resp;
-      resp.customHeader("Content-Type", "text/plain");
+      resp.header("Content-Type", "text/plain");
       resp.body(payload);
       return resp;
     });
@@ -725,7 +725,7 @@ TEST(HttpCompressionZstdBuffered, WildcardSelectsZstdIfPreferred) {
     ts.server.router().setDefault([payload](const HttpRequest &) {
       HttpResponse resp;
       resp.body(payload);
-      resp.customHeader("Content-Type", "text/plain");
+      resp.header("Content-Type", "text/plain");
       return resp;
     });
     auto resp = test::simpleGet(ts.port(), "/w", {{"Accept-Encoding", "*;q=0.9"}});
@@ -753,7 +753,7 @@ TEST(HttpCompressionZstdBuffered, TieBreakAgainstGzipHigherQ) {
     ts.server.router().setDefault([payload](const HttpRequest &) {
       HttpResponse resp;
       resp.body(payload);
-      resp.customHeader("Content-Type", "text/plain");
+      resp.header("Content-Type", "text/plain");
       return resp;
     });
     auto resp = test::simpleGet(ts.port(), "/t", {{"Accept-Encoding", "gzip;q=0.9, zstd;q=0.9"}});

--- a/tests/http-connect_test.cpp
+++ b/tests/http-connect_test.cpp
@@ -14,7 +14,7 @@ using namespace aeronet;
 
 class HttpConnectDefaultConfig : public ::testing::Test {
  public:
-  virtual ~HttpConnectDefaultConfig() = default;
+  ~HttpConnectDefaultConfig() override = default;
 
   test::TestServer ts{HttpServerConfig{}};
   test::ClientConnection client{ts.port()};

--- a/tests/http-date_test.cpp
+++ b/tests/http-date_test.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <thread>
 
 #include "aeronet/http-constants.hpp"

--- a/tests/http-options-trace_test.cpp
+++ b/tests/http-options-trace_test.cpp
@@ -83,9 +83,8 @@ class HttpCorsIntegration : public ::testing::Test {
 };
 
 TEST_F(HttpCorsIntegration, PreflightUsesRouterAllowedMethods) {
-  ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("ok");
-  });
+  ts.server.router().setPath(http::Method::GET, "/data",
+                             [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK).body("ok"); });
 
   test::RequestOptions opt;
   opt.method = "OPTIONS";
@@ -146,9 +145,8 @@ TEST_F(HttpCorsIntegration, PreflightOriginDeniedReturns403) {
 }
 
 TEST_F(HttpCorsIntegration, ActualRequestIncludesAllowOriginHeader) {
-  ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("ok");
-  });
+  ts.server.router().setPath(http::Method::GET, "/data",
+                             [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK).body("ok"); });
 
   test::RequestOptions opt;
   opt.method = "GET";
@@ -214,7 +212,7 @@ TEST_F(HttpCorsIntegration, StreamingResponseCarriesCorsHeaders) {
 TEST_F(HttpCorsIntegration, StreamingVaryHeaderAppendsOrigin) {
   ts.server.router().setPath(http::Method::GET, "/stream", [](const HttpRequest&, HttpResponseWriter& writer) {
     writer.status(http::StatusCodeOK);
-    writer.customHeader("Vary", "Accept-Encoding");
+    writer.header("Vary", "Accept-Encoding");
     writer.contentType("text/plain");
     writer.writeBody("data");
     writer.end();
@@ -264,9 +262,7 @@ TEST_F(HttpCorsIntegration, PerRouteCorsPolicyOverridesDefault_ActualAndPrefligh
 
   ts.server.router()
       .setPath(http::Method::GET, "/per",
-               [](const HttpRequest&) {
-                 return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("ok");
-               })
+               [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK).body("ok"); })
       .cors(std::move(per));
 
   // Actual request with allowed per-route origin
@@ -310,9 +306,8 @@ TEST(HttpCorsDetailed, PreflightWithCredentialsEmitsMirroredOriginAndCredentials
   routerCfg.withDefaultCorsPolicy(std::move(policy));
 
   test::TestServer ts(cfg, routerCfg);
-  ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("ok");
-  });
+  ts.server.router().setPath(http::Method::GET, "/data",
+                             [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK).body("ok"); });
 
   test::RequestOptions opt;
   opt.method = "OPTIONS";
@@ -340,9 +335,8 @@ TEST(HttpCorsDetailed, ActualRequestWithCredentialsEmitsCredentials) {
   routerCfg.withDefaultCorsPolicy(std::move(policy));
 
   test::TestServer ts(cfg, routerCfg);
-  ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("ok");
-  });
+  ts.server.router().setPath(http::Method::GET, "/data",
+                             [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK).body("ok"); });
 
   test::RequestOptions opt;
   opt.method = "GET";
@@ -370,9 +364,8 @@ TEST(HttpCorsDetailed, PreflightExposeHeadersAndMaxAge) {
   routerCfg.withDefaultCorsPolicy(std::move(policy));
 
   test::TestServer ts(cfg, routerCfg);
-  ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("ok");
-  });
+  ts.server.router().setPath(http::Method::GET, "/data",
+                             [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK).body("ok"); });
 
   test::RequestOptions opt;
   opt.method = "OPTIONS";
@@ -400,9 +393,8 @@ TEST(HttpCorsDetailed, PreflightPrivateNetworkHeader) {
   routerCfg.withDefaultCorsPolicy(std::move(policy));
 
   test::TestServer ts(cfg, routerCfg);
-  ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("ok");
-  });
+  ts.server.router().setPath(http::Method::GET, "/data",
+                             [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK).body("ok"); });
 
   test::RequestOptions opt;
   opt.method = "OPTIONS";
@@ -482,9 +474,8 @@ TEST(HttpCorsDetailed, VaryIncludesOriginWhenMirroring) {
     routerCfg.withDefaultCorsPolicy(std::move(policy));
 
     test::TestServer ts(cfg, routerCfg);
-    ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
-      return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("ok");
-    });
+    ts.server.router().setPath(http::Method::GET, "/data",
+                               [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK).body("ok"); });
 
     test::RequestOptions opt;
     opt.method = "GET";
@@ -511,7 +502,7 @@ TEST(HttpCorsDetailed, VaryIncludesOriginWhenMirroring) {
     test::TestServer ts(cfg, routerCfg);
     ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
       HttpResponse resp(http::StatusCodeOK);
-      resp.customHeader(http::Vary, "Accept-Encoding");
+      resp.header(http::Vary, "Accept-Encoding");
       return resp;
     });
 
@@ -541,7 +532,7 @@ TEST(HttpCorsDetailed, VaryNoDuplicateWhenOriginAlreadyPresent) {
   test::TestServer ts(cfg, routerCfg);
   ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
     HttpResponse resp(http::StatusCodeOK);
-    resp.addCustomHeader(http::Vary, "Origin");
+    resp.addHeader(http::Vary, "Origin");
     return resp;
   });
 
@@ -569,9 +560,8 @@ TEST(HttpCorsDetailed, MultipleAllowedOriginsMirrorCorrectOne) {
   routerCfg.withDefaultCorsPolicy(std::move(policy));
 
   test::TestServer ts(cfg, routerCfg);
-  ts.server.router().setPath(http::Method::GET, "/data", [](const HttpRequest&) {
-    return HttpResponse(http::StatusCodeOK).contentType(http::ContentTypeTextPlain).body("ok");
-  });
+  ts.server.router().setPath(http::Method::GET, "/data",
+                             [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK).body("ok"); });
 
   test::RequestOptions opt;
   opt.method = "GET";

--- a/tests/http-query-parsing_test.cpp
+++ b/tests/http-query-parsing_test.cpp
@@ -21,7 +21,7 @@ TEST(HttpQueryParsing, NoQuery) {
     EXPECT_EQ(req.path(), "/plain");
     EXPECT_EQ(req.queryParams().begin(), req.queryParams().end());
     HttpResponse resp;
-    resp.status(200).reason("OK").body("NOQ").contentType("text/plain");
+    resp.status(200).reason("OK").body("NOQ");
     return resp;
   });
   auto resp = test::simpleGet(ts.port(), "/plain");
@@ -43,7 +43,7 @@ TEST(HttpQueryParsing, SimpleQuery) {
     }
 
     HttpResponse resp(200, "OK");
-    resp.body(body).contentType("text/plain");
+    resp.body(body);
     return resp;
   });
   auto resp = test::simpleGet(ts.port(), "/p?a=1&b=2");
@@ -76,7 +76,7 @@ TEST(HttpQueryParsing, PercentDecodedQuery) {
       body.push_back('=');
       body.append(val);
     }
-    resp.status(200).reason("OK").body(body).contentType("text/plain");
+    resp.status(200).reason("OK").body(body);
     return resp;
   });
   auto resp = test::simpleGet(ts.port(), "/d?x=one%20two&y=%2Fpath");
@@ -90,7 +90,7 @@ TEST(HttpQueryParsing, EmptyQueryAndTrailingQMark) {
     // "?" with nothing after -> empty query view
     EXPECT_EQ(req.queryParams().begin(), req.queryParams().end());
     HttpResponse resp;
-    resp.status(200).reason("OK").body("EMPTY").contentType("text/plain");
+    resp.status(200).reason("OK").body("EMPTY");
     return resp;
   });
   auto resp = test::simpleGet(ts.port(), "/t?");
@@ -107,7 +107,7 @@ TEST(HttpQueryParsingEdge, IncompleteEscapeAtEndShouldBeAccepted) {
     EXPECT_EQ((*it).key, "x");
     EXPECT_EQ((*it).value, "%");
     HttpResponse resp(200, "OK");
-    resp.body("EDGE1").contentType("text/plain");
+    resp.body("EDGE1");
     return resp;
   });
   std::string out = test::simpleGet(ts.port(), "/e?x=%");
@@ -122,7 +122,7 @@ TEST(HttpQueryParsingEdge, IncompleteEscapeOneHexShouldBeAccepted) {
     // Invalid -> left as literal
     EXPECT_EQ((*it).value, "%A");
     HttpResponse resp(200, "OK");
-    resp.body("EDGE2").contentType("text/plain");
+    resp.body("EDGE2");
     return resp;
   });
   std::string resp = test::simpleGet(ts.port(), "/e2?a=%A");
@@ -148,7 +148,7 @@ TEST(HttpQueryParsingEdge, MultiplePairsAndEmptyValue) {
     ++it;
     EXPECT_EQ(it, range.end());
     HttpResponse resp(200, "OK");
-    resp.body("EDGE3").contentType("text/plain");
+    resp.body("EDGE3");
     return resp;
   });
   std::string resp = test::simpleGet(ts.port(), "/m?k=1&empty=&novalue");
@@ -164,7 +164,7 @@ TEST(HttpQueryParsingEdge, PercentDecodingKeyAndValue) {
     EXPECT_EQ((*it).key, "fo");
     EXPECT_EQ((*it).value, "bar baz");
     HttpResponse resp;
-    resp.status(200).reason("OK").body("EDGE4").contentType("text/plain");
+    resp.status(200).reason("OK").body("EDGE4");
     return resp;
   });
   std::string resp = test::simpleGet(ts.port(), "/pd?%66o=bar%20baz");
@@ -199,7 +199,7 @@ TEST(HttpQueryStructuredBindings, IterateKeyValues) {
     EXPECT_EQ(count, 4);
     EXPECT_TRUE(sawA && sawB && sawEmpty && sawNoValue);
     HttpResponse resp(200, "OK");
-    resp.body("OK").contentType("text/plain");
+    resp.body("OK");
     return resp;
   });
   // Build raw HTTP request using helpers

--- a/tests/http-routing_test.cpp
+++ b/tests/http-routing_test.cpp
@@ -4,7 +4,6 @@
 #include <string>
 #include <utility>
 
-#include "aeronet/http-constants.hpp"
 #include "aeronet/http-method.hpp"
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
@@ -22,13 +21,10 @@ test::TestServer ts(HttpServerConfig{});
 }
 
 TEST(HttpRouting, BasicPathDispatch) {
-  ts.server.router().setPath(http::Method::GET, "/hello", [](const HttpRequest&) {
-    return HttpResponse(http::StatusCodeOK, "OK").body("world").contentType(http::ContentTypeTextPlain);
-  });
+  ts.server.router().setPath(http::Method::GET, "/hello",
+                             [](const HttpRequest&) { return HttpResponse(http::StatusCodeOK, "OK").body("world"); });
   ts.server.router().setPath(http::Method::GET | http::Method::POST, "/multi", [](const HttpRequest& req) {
-    return HttpResponse(http::StatusCodeOK, "OK")
-        .body(std::string(http::toMethodStr(req.method())) + "!")
-        .contentType(http::ContentTypeTextPlain);
+    return HttpResponse(http::StatusCodeOK, "OK").body(std::string(http::toMethodStr(req.method())) + "!");
   });
 
   test::RequestOptions getHello;
@@ -75,7 +71,7 @@ TEST(HttpRouting, PathParametersInjectedIntoRequest) {
     if (const auto itPost = params.find("postId"); itPost != params.end()) {
       seenPost.assign(itPost->second);
     }
-    return HttpResponse(200, "OK").contentType(http::ContentTypeTextPlain).body("ok");
+    return HttpResponse(200, "OK").body("ok");
   });
 
   test::RequestOptions reqOpts;

--- a/tests/http-stats_test.cpp
+++ b/tests/http-stats_test.cpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <string>
 
-#include "aeronet/http-constants.hpp"
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-server-config.hpp"
@@ -18,9 +17,8 @@ TEST(HttpStats, BasicCountersIncrement) {
   HttpServerConfig cfg;
   cfg.withMaxRequestsPerConnection(5);
   test::TestServer ts(cfg);
-  ts.server.router().setDefault([]([[maybe_unused]] const HttpRequest& req) {
-    return HttpResponse(200, "OK").body("hello").contentType(http::ContentTypeTextPlain);
-  });
+  ts.server.router().setDefault(
+      []([[maybe_unused]] const HttpRequest& req) { return HttpResponse(200, "OK").body("hello"); });
   // Single request via throwing helper
   auto resp = test::requestOrThrow(ts.port());
   ASSERT_TRUE(resp.contains("200 OK"));

--- a/tests/http-tls-io_test.cpp
+++ b/tests/http-tls-io_test.cpp
@@ -32,7 +32,7 @@ TEST(HttpTlsBasic, LargePayload) {
     cfg.keepAliveTimeout = std::chrono::hours(1);
   });
   ts.setDefault([&largeBody]([[maybe_unused]] const HttpRequest& req) {
-    return HttpResponse(http::StatusCodeOK, "OK").contentType(http::ContentTypeTextPlain).body(largeBody);
+    return HttpResponse(http::StatusCodeOK, "OK").body(largeBody);
   });
   test::TlsClient client(ts.port());
   auto raw = client.get("/hello", {{"X-Test", "tls"}});
@@ -111,9 +111,7 @@ std::string tlsGetLarge(auto port) {
 TEST(HttpTlsNegative, LargeResponseFragmentation) {
   test::TlsTestServer ts;  // basic TLS
   auto port = ts.port();
-  ts.setDefault([](const HttpRequest&) {
-    return HttpResponse(200, "OK").contentType(http::ContentTypeTextPlain).body(std::string(300000, 'A'));
-  });
+  ts.setDefault([](const HttpRequest&) { return HttpResponse(200, "OK").body(std::string(300000, 'A')); });
   std::string resp = tlsGetLarge(port);
   // helper freed temporary key/cert
   ASSERT_FALSE(resp.empty());
@@ -178,7 +176,6 @@ TEST(HttpTlsStreaming, SendFileFallbackBuffers) {
   test::TlsTestServer ts({"http/1.1"});
   ts.setDefault([path](const HttpRequest&, HttpResponseWriter& writer) {
     writer.status(http::StatusCodeOK);
-    writer.contentType("application/octet-stream");
     writer.file(File(path));
     writer.end();
   });

--- a/tests/http-url-decoding_test.cpp
+++ b/tests/http-url-decoding_test.cpp
@@ -1,13 +1,8 @@
 #include <gtest/gtest.h>
 
-#include <atomic>
-#include <chrono>
 #include <string>
 #include <string_view>
-#include <thread>
-#include <utility>
 
-#include "aeronet/http-constants.hpp"
 #include "aeronet/http-method.hpp"
 #include "aeronet/http-request.hpp"
 #include "aeronet/http-response.hpp"
@@ -25,10 +20,7 @@ test::TestServer ts(HttpServerConfig{});
 
 TEST(HttpUrlDecoding, SpaceDecoding) {
   ts.server.router().setPath(http::Method::GET, "/hello world", [](const HttpRequest &req) {
-    return HttpResponse(http::StatusCodeOK)
-        .reason("OK")
-        .body(std::string(req.path()))
-        .contentType(http::ContentTypeTextPlain);
+    return HttpResponse(http::StatusCodeOK).reason("OK").body(std::string(req.path()));
   });
   test::RequestOptions optHello;
   optHello.method = "GET";
@@ -42,9 +34,8 @@ TEST(HttpUrlDecoding, SpaceDecoding) {
 TEST(HttpUrlDecoding, Utf8Decoded) {
   // Path contains snowman + space + 'x'
   std::string decodedPath = "/\xE2\x98\x83 x";  // /☃ x
-  ts.server.router().setPath(http::Method::GET, decodedPath, [](const HttpRequest &) {
-    return HttpResponse(200, "OK").body("utf8").contentType(http::ContentTypeTextPlain);
-  });
+  ts.server.router().setPath(http::Method::GET, decodedPath,
+                             [](const HttpRequest &) { return HttpResponse(200, "OK").body("utf8"); });
   // Percent-encoded UTF-8 for snowman (E2 98 83) plus %20 and 'x'
   test::RequestOptions optUtf8;
   optUtf8.method = "GET";
@@ -56,9 +47,8 @@ TEST(HttpUrlDecoding, Utf8Decoded) {
 }
 
 TEST(HttpUrlDecoding, PlusIsNotSpace) {
-  ts.server.router().setPath(http::Method::GET, "/a+b", [](const HttpRequest &) {
-    return HttpResponse(200, "OK").body("plus").contentType(http::ContentTypeTextPlain);
-  });
+  ts.server.router().setPath(http::Method::GET, "/a+b",
+                             [](const HttpRequest &) { return HttpResponse(200, "OK").body("plus"); });
   test::RequestOptions optPlus;
   optPlus.method = "GET";
   optPlus.target = "/a+b";
@@ -86,9 +76,8 @@ TEST(HttpUrlDecoding, IncompletePercentSequence400) {
 }
 
 TEST(HttpUrlDecoding, MixedSegmentsDecoding) {
-  ts.server.router().setPath(http::Method::GET, "/seg one/part%/two", [](const HttpRequest &req) {
-    return HttpResponse(200, "OK").body(req.path()).contentType(http::ContentTypeTextPlain);
-  });
+  ts.server.router().setPath(http::Method::GET, "/seg one/part%/two",
+                             [](const HttpRequest &req) { return HttpResponse(200, "OK").body(req.path()); });
   // encodes space in first segment only
   test::RequestOptions opt2;
   opt2.method = "GET";


### PR DESCRIPTION
# Contents

## HttpResponse

- Rename `addCustomHeader` in `addHeader`
- Rename `customHeader` in `header`
- Removed `contentType` method in favor of directly set from `body` or `file` method (enforcement to be as close to payload as possible)
- Detect file extension for static file service and set content type if extension is known
- Add more body set overloads, from `std::byte` buffers

## HttpResponseWriter

- Rename `addCustomHeader` in `addHeader`
- Rename `customHeader` in `header`
- Mimick content type header set from file as `HttpResponse`
