### PR TITLE
feat: do not emit Connection header when its value is the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 ## In a nutshell
 
 - **Fast & predictable**: edge‑triggered reactor model, zero/low‑allocation hot paths, horizontal scaling with port reuse
-- **Modular & opt‑in**: enable only the features you need (compression, TLS, logging, opentelemetry) via build flags
-- **Ergonomic**: ease of use, RAII listener setup, no hidden global state, no complex macros
-- **Configurable**: fully configurable with reasonable defaults
-- **Cloud native**: Built-in Kubernetes-style health & readiness probes, opentelemetry support (metrics & tracing), perfect for micro-services
+- **Modular & opt‑in**: enable only the features you need (compression, TLS, logging, opentelemetry) at compile time
+- **Ergonomic**: ease of use, RAII listener setup, no hidden global state, no macros
+- **Configurable**: fully configurable with reasonable defaults (principle of least surprise)
+- **Cloud native**: Built-in Kubernetes-style health probes, opentelemetry support (metrics, tracing), perfect for micro-services
 
 ## Minimal Examples
 
@@ -33,7 +33,7 @@ int main() {
     return HttpResponse(200).body("hello from aeronet\n");
   });
   HttpServer server(HttpServerConfig{}, std::move(router));
-  server.run();
+  server.run(); // blocking. Use start() for non-blocking
 }
 ```
 
@@ -57,6 +57,7 @@ Minimal server examples for typical use cases are provided in [examples](example
 ```bash
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
+
 ./build/examples/aeronet-minimal 8080   # or omit 8080 for ephemeral
 ```
 
@@ -68,7 +69,6 @@ curl -i http://localhost:8080/hello
 HTTP/1.1 200
 Content-Type: text/plain
 Content-Length: 151
-Connection: keep-alive
 Date: Wed, 12 Nov 2025 18:56:52 GMT
 Server: aeronet
 

--- a/aeronet/http/include/aeronet/http-response.hpp
+++ b/aeronet/http/include/aeronet/http-response.hpp
@@ -671,7 +671,7 @@ class HttpResponse {
 
   void appendHeaderInternal(std::string_view key, std::string_view value);
 
-  HttpPayload* finalizeHeadersBody(SysTimePoint tp, bool isHeadMethod, bool keepAlive,
+  HttpPayload* finalizeHeadersBody(http::Version version, SysTimePoint tp, bool isHeadMethod, bool close,
                                    std::span<const http::Header> globalHeaders, std::size_t minCapturedBodySize);
 
   void appendTrailer(std::string_view name, std::string_view value);
@@ -692,7 +692,7 @@ class HttpResponse {
   // IMPORTANT: This method finalizes the response by appending reserved headers,
   // and returns the internal buffers stolen from this HttpResponse instance.
   // So this instance must not be used anymore after this call.
-  PreparedResponse finalizeAndStealData(http::Version version, SysTimePoint tp, bool keepAlive,
+  PreparedResponse finalizeAndStealData(http::Version version, SysTimePoint tp, bool close,
                                         std::span<const http::Header> globalHeaders, bool isHeadMethod,
                                         std::size_t minCapturedBodySize);
 

--- a/aeronet/http/test/http-response_test.cpp
+++ b/aeronet/http/test/http-response_test.cpp
@@ -43,7 +43,7 @@ class HttpResponseTest : public ::testing::Test {
   static HttpResponse::PreparedResponse finalizePrepared(HttpResponse&& resp,
                                                          std::span<const http::Header> globalHeaders,
                                                          bool head = isHeadMethod, bool keepAliveFlag = keepAlive) {
-    return resp.finalizeAndStealData(http::HTTP_1_1, tp, keepAliveFlag, globalHeaders, head, minCapturedBodySize);
+    return resp.finalizeAndStealData(http::HTTP_1_1, tp, !keepAliveFlag, globalHeaders, head, minCapturedBodySize);
   }
 
   static HttpResponseData finalize(HttpResponse&& resp) {
@@ -130,7 +130,7 @@ TEST_F(HttpResponseTest, StatusReasonAndBodyOverridenLowerWithoutHeaders) {
 TEST_F(HttpResponseTest, StatusReasonAndBodyOverridenHigherWithHeaders) {
   HttpResponse resp(200, "OK");
   resp.addHeader("X-Header", "Value");
-  resp.status(404).reason("Not Found");
+  resp.status(404, "Not Found");
   EXPECT_EQ(resp.reason(), "Not Found");
   auto full = concatenated(std::move(resp));
 
@@ -153,9 +153,9 @@ TEST_F(HttpResponseTest, StatusReasonAndBodyOverridenLowerWithHeaders) {
 }
 
 TEST_F(HttpResponseTest, StatusReasonAndBodyAddReasonWithHeaders) {
-  HttpResponse resp(200, "");
+  HttpResponse resp(200);
   resp.addHeader("X-Header", "Value");
-  resp.status(404).reason("Not Found");
+  resp.status(404, "Not Found");
   EXPECT_EQ(resp.reason(), "Not Found");
   auto full = concatenated(std::move(resp));
 

--- a/aeronet/main/src/http-response-dispatch.cpp
+++ b/aeronet/main/src/http-response-dispatch.cpp
@@ -276,7 +276,7 @@ void HttpServer::finalizeAndSendResponse(ConnectionMapIt cnxIt, HttpResponse&& r
     }
   }
 
-  queuePreparedResponse(cnxIt, resp.finalizeAndStealData(_request.version(), SysClock::now(), keepAlive,
+  queuePreparedResponse(cnxIt, resp.finalizeAndStealData(_request.version(), SysClock::now(), !keepAlive,
                                                          _config.globalHeaders, isHead, _config.minCapturedBodySize));
 
   state.inBuffer.erase_front(consumedBytes);

--- a/aeronet/main/src/http-response-writer.cpp
+++ b/aeronet/main/src/http-response-writer.cpp
@@ -127,7 +127,7 @@ void HttpResponseWriter::ensureHeadersSent() {
   auto cnxIt = _server->_connStates.find(_fd);
   if (cnxIt == _server->_connStates.end() ||
       !_server->queuePreparedResponse(
-          cnxIt, _fixedResponse.finalizeAndStealData(http::HTTP_1_1, SysClock::now(), !_requestConnClose,
+          cnxIt, _fixedResponse.finalizeAndStealData(http::HTTP_1_1, SysClock::now(), _requestConnClose,
                                                      _server->config().globalHeaders, _head,
                                                      _server->config().minCapturedBodySize))) {
     _state = HttpResponseWriter::State::Failed;

--- a/tests/http-server-lifecycle_test.cpp
+++ b/tests/http-server-lifecycle_test.cpp
@@ -292,7 +292,7 @@ TEST(HttpDrain, KeepAliveConnectionsCloseAfterDrain) {
 
   test::sendAll(fd, SimpleGetRequest("/one", "keep-alive"));
   auto firstResponse = test::recvWithTimeout(fd);
-  ASSERT_TRUE(firstResponse.contains("Connection: keep-alive"));
+  ASSERT_FALSE(firstResponse.contains("Connection: close"));
 
   ts.server.beginDrain();
 

--- a/tests/multi-http-server_test.cpp
+++ b/tests/multi-http-server_test.cpp
@@ -152,7 +152,7 @@ TEST(MultiHttpServer, BeginDrainClosesKeepAliveConnections) {
 
   test::sendAll(fd, SimpleGetRequest("/", "keep-alive"));
   const auto initial = test::recvWithTimeout(fd);
-  ASSERT_TRUE(initial.contains("Connection: keep-alive"));
+  ASSERT_FALSE(initial.contains("Connection: close"));
 
   multi.beginDrain(200ms);
   EXPECT_TRUE(multi.isDraining());


### PR DESCRIPTION
For HTTP/1.0, do not emit `Connection: close`
For HTTP/1.1, do not emit `Connection: keep-alive`

because these values are the default for their respective HTTP version.