### PR TITLE
feat: improve HttpResponse compression performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,22 @@
 [![Packaging](https://github.com/sjanel/aeronet/actions/workflows/packaging.yml/badge.svg)](https://github.com/sjanel/aeronet/actions/workflows/packaging.yml)
 [![clang-format](https://github.com/sjanel/aeronet/actions/workflows/clang-format-check.yml/badge.svg)](https://github.com/sjanel/aeronet/actions/workflows/clang-format-check.yml)
 
+## Why aeronet?
+
 **aeronet** is a modern, fast, modular and ergonomic HTTP/1.1 C++ **server library** for **Linux** focused on predictable performance, explicit control and minimal dependencies.
 
-## In a nutshell
-
-- **Fast & predictable**: edge‑triggered reactor model, zero/low‑allocation hot paths, horizontal scaling with port reuse
-- **Modular & opt‑in**: enable only the features you need (compression, TLS, logging, opentelemetry) at compile time
-- **Ergonomic**: ease of use, RAII listener setup, no hidden global state, no macros
-- **Configurable**: fully configurable with reasonable defaults (principle of least surprise)
+- **Fast & predictable**: edge‑triggered reactor model, zero/low‑allocation hot paths and minimal copies, horizontal scaling with port reuse
+- **Modular & opt‑in**: enable only the features you need at compile time to minimize binary size and dependencies
+- **Ergonomic**: easy API, automatic features (encoding, telemetry), RAII listener setup with sync / async server lifetime control, no hidden global state, no macros
+- **Configurable**: extensive dynamic configuration with reasonable defaults (principle of least surprise)
+- **Standards compliant**: Compression, Streaming, Trailers, TLS, CORS, Range Requests, Conditional Requests, Static files, Percent Decoding, etc.
 - **Cloud native**: Built-in Kubernetes-style health probes, opentelemetry support (metrics, tracing), perfect for micro-services
 
 ## Minimal Examples
 
 Spin up a basic HTTP/1.1 server that responds on `/hello` in just a few lines. If you pass `0` as the port (or omit it), the kernel picks an ephemeral port which you can query immediately.
 
-### HTTP response
+### Immediate response
 
 ```cpp
 #include <aeronet/aeronet.hpp>

--- a/aeronet/main/include/aeronet/http-server.hpp
+++ b/aeronet/main/include/aeronet/http-server.hpp
@@ -457,6 +457,8 @@ class HttpServer {
 
   void registerBuiltInProbes();
 
+  void createEncoders();
+
   void submitRouterUpdate(std::function<void(Router&)> updater,
                           std::shared_ptr<std::promise<std::exception_ptr>> completion);
 
@@ -508,9 +510,9 @@ class HttpServer {
 
   ConnectionMap _connStates;
 
-  // Pre-allocated encoders (one per supported format) constructed once at server creation.
+  // Pre-allocated encoders (one per supported format), -1 to remove identity which is last (no encoding).
   // Index corresponds to static_cast<size_t>(Encoding).
-  std::array<std::unique_ptr<Encoder>, kNbContentEncodings> _encoders;
+  std::array<std::unique_ptr<Encoder>, kNbContentEncodings - 1> _encoders;
   EncodingSelector _encodingSelector;
 
   ParserErrorCallback _parserErrCb = []([[maybe_unused]] http::StatusCode) {};

--- a/aeronet/objects/CMakeLists.txt
+++ b/aeronet/objects/CMakeLists.txt
@@ -137,6 +137,15 @@ add_unit_test(
     aeronet_tech
 )
 
+if(AERONET_ENABLE_BROTLI)
+    add_unit_test(
+        brotli-encoder-decoder_test
+        test/brotli-encoder-decoder_test.cpp
+        LIBRARIES
+        aeronet_objects
+    )
+endif()
+
 add_unit_test(
     http-payload_test
     test/http-payload_test.cpp
@@ -179,3 +188,21 @@ add_unit_test(
     LIBRARIES
     aeronet_objects
 )
+
+if(AERONET_ENABLE_ZLIB)
+    add_unit_test(
+        zlib-encoder-decoder_test
+        test/zlib-encoder-decoder_test.cpp
+        LIBRARIES
+        aeronet_objects
+    )
+endif()
+
+if(AERONET_ENABLE_ZSTD)
+    add_unit_test(
+        zstd-encoder-decoder_test
+        test/zstd-encoder-decoder_test.cpp
+        LIBRARIES
+        aeronet_objects
+    )
+endif()

--- a/aeronet/objects/include/aeronet/brotli-encoder.hpp
+++ b/aeronet/objects/include/aeronet/brotli-encoder.hpp
@@ -29,7 +29,7 @@ class BrotliEncoder : public Encoder {
   explicit BrotliEncoder(const CompressionConfig &cfg, std::size_t initialCapacity = 4096UL)
       : _buf(initialCapacity), _quality(cfg.brotli.quality), _window(cfg.brotli.window) {}
 
-  std::string_view encodeFull(std::size_t encoderChunkSize, std::string_view full) override;
+  void encodeFull(std::size_t extraCapacity, std::string_view data, RawChars &buf) override;
 
   std::unique_ptr<EncoderContext> makeContext() override {
     return std::make_unique<BrotliEncoderContext>(_buf, _quality, _window);

--- a/aeronet/objects/include/aeronet/zlib-encoder.hpp
+++ b/aeronet/objects/include/aeronet/zlib-encoder.hpp
@@ -50,17 +50,13 @@ class ZlibEncoder : public Encoder {
                        std::size_t initialCapacity = 4096UL)
       : _buf(initialCapacity), _level(cfg.zlib.level), _variant(variant) {}
 
-  std::string_view encodeFull(std::size_t encoderChunkSize, std::string_view in) override {
-    return compressAll(encoderChunkSize, in);
-  }
+  void encodeFull(std::size_t extraCapacity, std::string_view data, RawChars& buf) override;
 
   std::unique_ptr<EncoderContext> makeContext() override {
     return std::make_unique<ZlibEncoderContext>(_variant, _buf, _level);
   }
 
  private:
-  std::string_view compressAll(std::size_t encoderChunkSize, std::string_view in);
-
   RawChars _buf;  // shared output buffer reused (single-thread guarantee)
   int8_t _level;
   details::ZStreamRAII::Variant _variant;

--- a/aeronet/objects/src/brotli-decoder.cpp
+++ b/aeronet/objects/src/brotli-decoder.cpp
@@ -36,7 +36,7 @@ bool BrotliDecoder::Decompress(std::string_view input, std::size_t maxDecompress
   while (true) {
     out.ensureAvailableCapacityExponential(decoderChunkSize);
     uint8_t *nextOut = reinterpret_cast<uint8_t *>(out.data() + out.size());
-    std::size_t availOut = out.capacity() - out.size();
+    std::size_t availOut = out.availableCapacity();
 
     auto res = BrotliDecoderDecompressStream(state._state, &availIn, &nextIn, &availOut, &nextOut, nullptr);
     out.setSize(out.capacity() - availOut);

--- a/aeronet/objects/src/zlib-decoder.cpp
+++ b/aeronet/objects/src/zlib-decoder.cpp
@@ -41,7 +41,7 @@ bool ZlibDecoder::Decompress(std::string_view input, bool isGzip, std::size_t ma
 
   while (true) {
     out.ensureAvailableCapacityExponential(decoderChunkSize);
-    strm._strm.avail_out = static_cast<uInt>(out.capacity() - out.size());
+    strm._strm.avail_out = static_cast<uInt>(out.availableCapacity());
     strm._strm.next_out = reinterpret_cast<unsigned char *>(out.data() + out.size());
 
     const auto ret = inflate(&strm._strm, 0);

--- a/aeronet/objects/src/zstd-decoder.cpp
+++ b/aeronet/objects/src/zstd-decoder.cpp
@@ -63,7 +63,7 @@ bool ZstdDecoder::Decompress(std::string_view input, std::size_t maxDecompressed
 
   while (inBuf.pos < inBuf.size) {
     out.ensureAvailableCapacityExponential(decoderChunkSize);
-    ZSTD_outBuffer output{out.data() + out.size(), out.capacity() - out.size(), 0};
+    ZSTD_outBuffer output{out.data() + out.size(), out.availableCapacity(), 0};
     const std::size_t ret = ZSTD_decompressStream(ss._stream, &output, &inBuf);
     if (ZSTD_isError(ret) != 0U) {
       log::error("ZstdDecoder::Decompress - ZSTD_decompressStream failed with error {}", ret);

--- a/aeronet/objects/test/brotli-encoder-decoder_test.cpp
+++ b/aeronet/objects/test/brotli-encoder-decoder_test.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "aeronet/brotli-decoder.hpp"
+#include "aeronet/brotli-encoder.hpp"
+#include "aeronet/compression-config.hpp"
+#include "aeronet/raw-chars.hpp"
+
+namespace {
+
+constexpr std::size_t kEncoderChunkSize = 1024;
+constexpr std::size_t kDecoderChunkSize = 256;
+constexpr std::size_t kExtraCapacity = 0;
+constexpr std::size_t kMaxPlainBytes = 2UL * 1024 * 1024;
+
+std::string makePatternedPayload(std::size_t size) {
+  std::string payload;
+  payload.reserve(size);
+  for (std::size_t pos = 0; pos < size; ++pos) {
+    payload.push_back(static_cast<char>('a' + static_cast<int>(pos % 23U)));
+  }
+  return payload;
+}
+
+std::vector<std::string> samplePayloads() {
+  std::vector<std::string> payloads;
+  payloads.emplace_back("");
+  payloads.emplace_back("Hello, Brotli compression!");
+  payloads.emplace_back(512, 'A');
+  payloads.emplace_back(makePatternedPayload(128UL * 1024UL));
+  return payloads;
+}
+
+void ExpectOneShotRoundTrip(aeronet::BrotliEncoder& encoder, std::string_view payload) {
+  aeronet::RawChars compressed;
+  encoder.encodeFull(kExtraCapacity, payload, compressed);
+  aeronet::RawChars decompressed;
+  ASSERT_TRUE(aeronet::BrotliDecoder::Decompress(std::string_view(compressed), kMaxPlainBytes, kDecoderChunkSize,
+                                                 decompressed));
+  EXPECT_EQ(std::string_view(decompressed), payload);
+}
+
+void ExpectStreamingRoundTrip(aeronet::BrotliEncoder& encoder, std::string_view payload, std::size_t split) {
+  aeronet::RawChars compressed;
+  auto ctx = encoder.makeContext();
+  std::string_view remaining = payload;
+  while (!remaining.empty()) {
+    const std::size_t take = std::min(split, remaining.size());
+    const auto chunk = remaining.substr(0, take);
+    remaining.remove_prefix(take);
+    const auto produced = ctx->encodeChunk(kEncoderChunkSize, chunk);
+    if (!produced.empty()) {
+      compressed.append(produced);
+    }
+  }
+  const auto tail = ctx->encodeChunk(kEncoderChunkSize, {});
+  if (!tail.empty()) {
+    compressed.append(tail);
+  }
+
+  aeronet::RawChars decompressed;
+  ASSERT_TRUE(aeronet::BrotliDecoder::Decompress(std::string_view(compressed), kMaxPlainBytes, kDecoderChunkSize,
+                                                 decompressed));
+  EXPECT_EQ(std::string_view(decompressed), payload);
+}
+
+}  // namespace
+
+TEST(BrotliEncoderDecoderTest, EncodeFullRoundTripsPayloads) {
+  aeronet::CompressionConfig cfg;
+  aeronet::BrotliEncoder encoder(cfg);
+
+  for (const auto& payload : samplePayloads()) {
+    SCOPED_TRACE(testing::Message() << "payload bytes=" << payload.size());
+    ExpectOneShotRoundTrip(encoder, payload);
+  }
+}
+
+TEST(BrotliEncoderDecoderTest, StreamingRoundTripsAcrossChunkSplits) {
+  aeronet::CompressionConfig cfg;
+  aeronet::BrotliEncoder encoder(cfg);
+
+  constexpr std::array<std::size_t, 4> kSplits{1U, 5U, 113U, 4096U};
+  for (const auto& payload : samplePayloads()) {
+    for (const auto split : kSplits) {
+      SCOPED_TRACE(testing::Message() << "payload bytes=" << payload.size() << " split=" << split);
+      ExpectStreamingRoundTrip(encoder, payload, split);
+    }
+  }
+}

--- a/aeronet/objects/test/zlib-encoder-decoder_test.cpp
+++ b/aeronet/objects/test/zlib-encoder-decoder_test.cpp
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "aeronet/compression-config.hpp"
+#include "aeronet/raw-chars.hpp"
+#include "aeronet/zlib-decoder.hpp"
+#include "aeronet/zlib-encoder.hpp"
+
+namespace {
+
+constexpr std::size_t kEncoderChunkSize = 1536;
+constexpr std::size_t kDecoderChunkSize = 512;
+constexpr std::size_t kExtraCapacity = 0;
+constexpr std::size_t kMaxPlainBytes = 2UL * 1024 * 1024;
+
+std::string makePatternedPayload(std::size_t size) {
+  std::string payload;
+  payload.reserve(size);
+  for (std::size_t pos = 0; pos < size; ++pos) {
+    payload.push_back(static_cast<char>('a' + static_cast<int>(pos % 13U)));
+  }
+  return payload;
+}
+
+std::vector<std::string> samplePayloads() {
+  std::vector<std::string> payloads;
+  payloads.emplace_back("");
+  payloads.emplace_back("gzip -> deflate parity test");
+  payloads.emplace_back(2048, 'x');
+  payloads.emplace_back(makePatternedPayload(64UL * 1024UL));
+  return payloads;
+}
+
+const char* variantName(aeronet::details::ZStreamRAII::Variant variant) {
+  return variant == aeronet::details::ZStreamRAII::Variant::gzip ? "gzip" : "deflate";
+}
+
+void ExpectOneShotRoundTrip(aeronet::details::ZStreamRAII::Variant variant, std::string_view payload) {
+  aeronet::CompressionConfig cfg;
+  aeronet::ZlibEncoder encoder(variant, cfg);
+  aeronet::RawChars compressed;
+  encoder.encodeFull(kExtraCapacity, payload, compressed);
+
+  const bool isGzip = variant == aeronet::details::ZStreamRAII::Variant::gzip;
+  aeronet::RawChars decompressed;
+  ASSERT_TRUE(aeronet::ZlibDecoder::Decompress(std::string_view(compressed), isGzip, kMaxPlainBytes, kDecoderChunkSize,
+                                               decompressed));
+  EXPECT_EQ(std::string_view(decompressed), payload);
+}
+
+void ExpectStreamingRoundTrip(aeronet::details::ZStreamRAII::Variant variant, std::string_view payload,
+                              std::size_t split) {
+  aeronet::CompressionConfig cfg;
+  aeronet::ZlibEncoder encoder(variant, cfg);
+  aeronet::RawChars compressed;
+  auto ctx = encoder.makeContext();
+  std::string_view remaining = payload;
+  while (!remaining.empty()) {
+    const std::size_t take = std::min(split, remaining.size());
+    const auto chunk = remaining.substr(0, take);
+    remaining.remove_prefix(take);
+    const auto produced = ctx->encodeChunk(kEncoderChunkSize, chunk);
+    if (!produced.empty()) {
+      compressed.append(produced);
+    }
+  }
+  const auto tail = ctx->encodeChunk(kEncoderChunkSize, {});
+  if (!tail.empty()) {
+    compressed.append(tail);
+  }
+
+  const bool isGzip = variant == aeronet::details::ZStreamRAII::Variant::gzip;
+  aeronet::RawChars decompressed;
+  ASSERT_TRUE(aeronet::ZlibDecoder::Decompress(std::string_view(compressed), isGzip, kMaxPlainBytes, kDecoderChunkSize,
+                                               decompressed));
+  EXPECT_EQ(std::string_view(decompressed), payload);
+}
+
+}  // namespace
+
+class ZlibEncoderDecoderTest : public ::testing::TestWithParam<aeronet::details::ZStreamRAII::Variant> {};
+
+INSTANTIATE_TEST_SUITE_P(Variants, ZlibEncoderDecoderTest,
+                         ::testing::Values(aeronet::details::ZStreamRAII::Variant::gzip,
+                                           aeronet::details::ZStreamRAII::Variant::deflate));
+
+TEST_P(ZlibEncoderDecoderTest, EncodeFullRoundTripsPayloads) {
+  const auto variant = GetParam();
+  for (const auto& payload : samplePayloads()) {
+    SCOPED_TRACE(testing::Message() << variantName(variant) << " payload bytes=" << payload.size());
+    ExpectOneShotRoundTrip(variant, payload);
+  }
+}
+
+TEST_P(ZlibEncoderDecoderTest, StreamingRoundTripsAcrossChunkSplits) {
+  const auto variant = GetParam();
+  constexpr std::array<std::size_t, 4> kSplits{1U, 9U, 257U, 4096U};
+  for (const auto& payload : samplePayloads()) {
+    for (const auto split : kSplits) {
+      SCOPED_TRACE(testing::Message() << variantName(variant) << " payload bytes=" << payload.size()
+                                      << " split=" << split);
+      ExpectStreamingRoundTrip(variant, payload, split);
+    }
+  }
+}

--- a/aeronet/objects/test/zstd-encoder-decoder_test.cpp
+++ b/aeronet/objects/test/zstd-encoder-decoder_test.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "aeronet/compression-config.hpp"
+#include "aeronet/raw-chars.hpp"
+#include "aeronet/zstd-decoder.hpp"
+#include "aeronet/zstd-encoder.hpp"
+
+namespace {
+
+constexpr std::size_t kEncoderChunkSize = 2048;
+constexpr std::size_t kDecoderChunkSize = 512;
+constexpr std::size_t kExtraCapacity = 0;
+constexpr std::size_t kMaxPlainBytes = 4UL * 1024 * 1024;
+
+std::string makePatternedPayload(std::size_t size) {
+  std::string payload;
+  payload.reserve(size);
+  for (std::size_t pos = 0; pos < size; ++pos) {
+    payload.push_back(static_cast<char>('A' + static_cast<int>(pos % 17U)));
+  }
+  return payload;
+}
+
+std::vector<std::string> samplePayloads() {
+  std::vector<std::string> payloads;
+  payloads.emplace_back("");
+  payloads.emplace_back("Zstd keeps strings sharp.");
+  payloads.emplace_back(4096, 'Z');
+  payloads.emplace_back(makePatternedPayload(256UL * 1024UL));
+  return payloads;
+}
+
+void ExpectOneShotRoundTrip(std::string_view payload) {
+  aeronet::CompressionConfig cfg;
+  aeronet::ZstdEncoder encoder(cfg);
+  aeronet::RawChars compressed;
+  encoder.encodeFull(kExtraCapacity, payload, compressed);
+
+  aeronet::RawChars decompressed;
+  ASSERT_TRUE(
+      aeronet::ZstdDecoder::Decompress(std::string_view(compressed), kMaxPlainBytes, kDecoderChunkSize, decompressed));
+  EXPECT_EQ(std::string_view(decompressed), payload);
+}
+
+void ExpectStreamingRoundTrip(std::string_view payload, std::size_t split) {
+  aeronet::CompressionConfig cfg;
+  aeronet::ZstdEncoder encoder(cfg);
+  aeronet::RawChars compressed;
+  auto ctx = encoder.makeContext();
+  std::string_view remaining = payload;
+  while (!remaining.empty()) {
+    const std::size_t take = std::min(split, remaining.size());
+    const auto chunk = remaining.substr(0, take);
+    remaining.remove_prefix(take);
+    const auto produced = ctx->encodeChunk(kEncoderChunkSize, chunk);
+    if (!produced.empty()) {
+      compressed.append(produced);
+    }
+  }
+  const auto tail = ctx->encodeChunk(kEncoderChunkSize, {});
+  if (!tail.empty()) {
+    compressed.append(tail);
+  }
+
+  aeronet::RawChars decompressed;
+  ASSERT_TRUE(
+      aeronet::ZstdDecoder::Decompress(std::string_view(compressed), kMaxPlainBytes, kDecoderChunkSize, decompressed));
+  EXPECT_EQ(std::string_view(decompressed), payload);
+}
+
+}  // namespace
+
+TEST(ZstdEncoderDecoderTest, EncodeFullRoundTripsPayloads) {
+  for (const auto& payload : samplePayloads()) {
+    SCOPED_TRACE(testing::Message() << "payload bytes=" << payload.size());
+    ExpectOneShotRoundTrip(payload);
+  }
+}
+
+TEST(ZstdEncoderDecoderTest, StreamingRoundTripsAcrossChunkSplits) {
+  constexpr std::array<std::size_t, 4> kSplits{1U, 7U, 257U, 8192U};
+  for (const auto& payload : samplePayloads()) {
+    for (const auto split : kSplits) {
+      SCOPED_TRACE(testing::Message() << "payload bytes=" << payload.size() << " split=" << split);
+      ExpectStreamingRoundTrip(payload, split);
+    }
+  }
+}

--- a/aeronet/tech/include/aeronet/internal/raw-bytes-base.hpp
+++ b/aeronet/tech/include/aeronet/internal/raw-bytes-base.hpp
@@ -76,6 +76,8 @@ class RawBytesBase {
 
   [[nodiscard]] size_type capacity() const noexcept { return _capacity; }
 
+  [[nodiscard]] size_type availableCapacity() const noexcept { return _capacity - _size; }
+
   void reserveExponential(size_type newCapacity);
 
   void reserve(size_type newCapacity);


### PR DESCRIPTION
This PR removes a `memcpy` occurring when `HttpResponse` are compressed.
Thanks to the dual buffer model of `HttpResponse`, we can write directly the compressed data into the inline buffer of the `HttpResponse` if the body is external, and vice versa.