### PR TITLE
feat: streaming decompression phase 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you are evaluating the library, the feature highlights above plus the minimal
 | Duplicate header policy | ✔ | Deterministic, security‑minded |
 | Trailers exposure | ✔ | RFC 7230 §4.1.2 chunked trailer headers |
 | Middleware helpers | ✔ | Global + per-route request/response hooks (streaming-aware) |
-| Streaming inbound decompression | ✖ | Planned |
+| Streaming inbound decompression | ✔ | Auto-switches to streaming inflaters once Content-Length exceeds configured threshold |
 | sendfile / static file helper | ✔ | 0.4.x – zero-copy plain sockets plus RFC 7233 single-range & RFC 7232 validators |
 
 ## Developer / Operational Features

--- a/aeronet/http/test/http-method_test.cpp
+++ b/aeronet/http/test/http-method_test.cpp
@@ -9,6 +9,7 @@
 #include <string_view>
 
 #include "../src/http-method-parse.hpp"
+#include "aeronet/toupperlower.hpp"
 
 namespace {
 
@@ -39,8 +40,7 @@ std::string ToLower(std::string_view token) {
   std::string lower;
   lower.reserve(token.size());
   for (char ch : token) {
-    const unsigned char uch = static_cast<unsigned char>(ch);
-    lower.push_back(static_cast<char>(std::tolower(uch)));
+    lower.push_back(aeronet::tolower(ch));
   }
   return lower;
 }
@@ -49,8 +49,8 @@ std::string AlternateCase(std::string_view token) {
   std::string mixed;
   mixed.reserve(token.size());
   for (std::size_t i = 0; i < token.size(); ++i) {
-    const unsigned char ch = static_cast<unsigned char>(token[i]);
-    mixed.push_back(i % 2 == 0 ? static_cast<char>(std::tolower(ch)) : static_cast<char>(std::toupper(ch)));
+    const char ch = token[i];
+    mixed.push_back(i % 2 == 0 ? aeronet::tolower(ch) : aeronet::toupper(ch));
   }
   return mixed;
 }

--- a/aeronet/objects/include/aeronet/brotli-decoder.hpp
+++ b/aeronet/objects/include/aeronet/brotli-decoder.hpp
@@ -1,17 +1,24 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <string_view>
 
+#include "aeronet/decoder.hpp"
 #include "aeronet/raw-chars.hpp"
 
 namespace aeronet {
 
-class BrotliDecoder {
+class BrotliDecoder : public Decoder {
  public:
   // Decompresses full brotli-encoded input into out. Returns true on success; false on error or size guard.
   static bool Decompress(std::string_view input, std::size_t maxDecompressedBytes, std::size_t decoderChunkSize,
                          RawChars &out);
+
+  bool decompressFull(std::string_view input, std::size_t maxDecompressedBytes, std::size_t decoderChunkSize,
+                      RawChars &out) override;
+
+  std::unique_ptr<DecoderContext> makeContext() override;
 };
 
 }  // namespace aeronet

--- a/aeronet/objects/include/aeronet/decoder.hpp
+++ b/aeronet/objects/include/aeronet/decoder.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string_view>
+
+#include "aeronet/raw-chars.hpp"
+
+namespace aeronet {
+
+// Streaming decoder abstraction mirroring Encoder/EncoderContext.
+// Implementations may reuse internal buffers but are not thread-safe.
+class DecoderContext {
+ public:
+  virtual ~DecoderContext() = default;
+
+  // Feed a compressed chunk into the context.
+  // When finalChunk is true, the caller does not provide any additional input.
+  // Implementations append plain bytes to 'out'.
+  virtual bool decompressChunk(std::string_view chunk, bool finalChunk, std::size_t maxDecompressedBytes,
+                               std::size_t decoderChunkSize, RawChars &out) = 0;
+};
+
+class Decoder {
+ public:
+  virtual ~Decoder() = default;
+
+  // Convenience helper for full-buffer decompression.
+  virtual bool decompressFull(std::string_view input, std::size_t maxDecompressedBytes, std::size_t decoderChunkSize,
+                              RawChars &out) = 0;
+
+  // Create a streaming context for incremental decode.
+  virtual std::unique_ptr<DecoderContext> makeContext() = 0;
+};
+
+}  // namespace aeronet

--- a/aeronet/objects/include/aeronet/decompression-config.hpp
+++ b/aeronet/objects/include/aeronet/decompression-config.hpp
@@ -34,6 +34,10 @@ struct DecompressionConfig {
   // overhead.
   std::size_t decoderChunkSize{32UL * 1024UL};
 
+  // When Content-Length is greater or equal to this threshold (bytes), inbound decompression switches to streaming
+  // contexts to avoid allocating full intermediate buffers for very large payloads. 0 => always use aggregated mode.
+  std::size_t streamingActivationContentLength{0};
+
   // Ratio guard: if decompressed_size > compressed_size * maxExpansionRatio the request is
   // rejected (413) even if maxDecompressedBytes is not exceeded. This quickly rejects "compression
   // bombs" that expand massively but still under absolute byte cap if not configured tightly.

--- a/aeronet/objects/include/aeronet/zlib-decoder.hpp
+++ b/aeronet/objects/include/aeronet/zlib-decoder.hpp
@@ -3,18 +3,29 @@
 #include <cstddef>
 #include <string_view>
 
+#include "aeronet/decoder.hpp"
 #include "aeronet/raw-chars.hpp"
 
 namespace aeronet {
 
 // Minimal full-buffer zlib/gzip inflate helper used for inbound request decompression.
 // Not exposed publicly; header installed only because internal components span static libs.
-class ZlibDecoder {
+class ZlibDecoder : public Decoder {
  public:
+  explicit ZlibDecoder(bool isGzip) : _isGzip(isGzip) {}
+
   // Returns true on success; false if inflate fails or limits exceeded. Output appended to out.
   // isGzip selects window bits to enable gzip wrapper decoding.
   static bool Decompress(std::string_view input, bool isGzip, std::size_t maxDecompressedBytes,
                          std::size_t decoderChunkSize, RawChars &out);
+
+  bool decompressFull(std::string_view input, std::size_t maxDecompressedBytes, std::size_t decoderChunkSize,
+                      RawChars &out) override;
+
+  std::unique_ptr<DecoderContext> makeContext() override;
+
+ private:
+  bool _isGzip{false};
 };
 
 }  // namespace aeronet

--- a/aeronet/objects/include/aeronet/zstd-decoder.hpp
+++ b/aeronet/objects/include/aeronet/zstd-decoder.hpp
@@ -3,17 +3,23 @@
 #include <cstddef>
 #include <string_view>
 
+#include "aeronet/decoder.hpp"
 #include "aeronet/raw-chars.hpp"
 
 namespace aeronet {
 
-class ZstdDecoder {
+class ZstdDecoder : public Decoder {
  public:
   // Attempts to fully decompress input into out (append). Returns true on success; false on error
   // or if decompressed size would exceed maxDecompressedBytes. Uses an adaptive growth strategy
   // since the uncompressed size may be unknown (no content size header present in frame).
   static bool Decompress(std::string_view input, std::size_t maxDecompressedBytes, std::size_t decoderChunkSize,
                          RawChars &out);
+
+  bool decompressFull(std::string_view input, std::size_t maxDecompressedBytes, std::size_t decoderChunkSize,
+                      RawChars &out) override;
+
+  std::unique_ptr<DecoderContext> makeContext() override;
 };
 
 }  // namespace aeronet

--- a/aeronet/objects/src/brotli-decoder.cpp
+++ b/aeronet/objects/src/brotli-decoder.cpp
@@ -4,63 +4,85 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <string_view>
 
+#include "aeronet/decoder.hpp"
 #include "aeronet/raw-chars.hpp"
 
 namespace aeronet {
 
 namespace {
-struct BrotliRAII {
-  explicit BrotliRAII(BrotliDecoderState *state) noexcept : _state(state) {}
 
-  BrotliRAII(const BrotliRAII &) = delete;
-  BrotliRAII(BrotliRAII &&) noexcept = delete;
-  BrotliRAII &operator=(const BrotliRAII &) = delete;
-  BrotliRAII &operator=(BrotliRAII &&) noexcept = delete;
+using BrotliStateUniquePtr = std::unique_ptr<BrotliDecoderState, decltype(&BrotliDecoderDestroyInstance)>;
 
-  ~BrotliRAII() { BrotliDecoderDestroyInstance(_state); }
+class BrotliStreamingContext final : public DecoderContext {
+ public:
+  BrotliStreamingContext() {
+    if (_state == nullptr) {
+      throw std::runtime_error("BrotliStreamingContext - BrotliDecoderCreateInstance failed");
+    }
+  }
 
-  BrotliDecoderState *_state;
+  bool decompressChunk(std::string_view chunk, bool finalChunk, std::size_t maxDecompressedBytes,
+                       std::size_t decoderChunkSize, RawChars &out) override {
+    if (finished()) {
+      return chunk.empty();
+    }
+    if (chunk.empty()) {
+      return finalChunk ? finished() : true;
+    }
+
+    const auto *nextIn = reinterpret_cast<const uint8_t *>(chunk.data());
+    std::size_t availIn = chunk.size();
+
+    while (true) {
+      out.ensureAvailableCapacityExponential(decoderChunkSize);
+      auto *nextOut = reinterpret_cast<uint8_t *>(out.data() + out.size());
+      std::size_t availOut = out.availableCapacity();
+
+      auto res = BrotliDecoderDecompressStream(_state.get(), &availIn, &nextIn, &availOut, &nextOut, nullptr);
+      out.setSize(out.capacity() - availOut);
+      if (maxDecompressedBytes != 0 && out.size() > maxDecompressedBytes) {
+        return false;
+      }
+
+      if (res == BROTLI_DECODER_RESULT_SUCCESS) {
+        _state.reset();
+        return availIn == 0;
+      }
+      if (res == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
+        continue;
+      }
+      if (res == BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT) {
+        if (availIn != 0) {
+          return false;
+        }
+        return !finalChunk;
+      }
+      return false;
+    }
+  }
+
+ private:
+  [[nodiscard]] bool finished() const noexcept { return _state == nullptr; }
+
+  BrotliStateUniquePtr _state{BrotliDecoderCreateInstance(nullptr, nullptr, nullptr), &BrotliDecoderDestroyInstance};
 };
 }  // namespace
 
 bool BrotliDecoder::Decompress(std::string_view input, std::size_t maxDecompressedBytes, std::size_t decoderChunkSize,
                                RawChars &out) {
-  BrotliRAII state(BrotliDecoderCreateInstance(nullptr, nullptr, nullptr));
-  if (state._state == nullptr) {
-    return false;
-  }
-  const uint8_t *nextIn = reinterpret_cast<const uint8_t *>(input.data());
-  std::size_t availIn = input.size();
-  while (true) {
-    out.ensureAvailableCapacityExponential(decoderChunkSize);
-    uint8_t *nextOut = reinterpret_cast<uint8_t *>(out.data() + out.size());
-    std::size_t availOut = out.availableCapacity();
-
-    auto res = BrotliDecoderDecompressStream(state._state, &availIn, &nextIn, &availOut, &nextOut, nullptr);
-    out.setSize(out.capacity() - availOut);
-
-    if (BrotliDecoderHasMoreOutput(state._state) != 0 && availOut == 0) {
-      continue;  // need more output space
-    }
-    if (res == BROTLI_DECODER_RESULT_SUCCESS) {
-      return true;
-    }
-    if (res == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
-      if (out.size() > maxDecompressedBytes) {
-        return false;
-      }
-      continue;
-    }
-    if (res == BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT) {
-      // Should not happen if we provided entire frame unless truncated
-      // treat as corruption
-      return false;
-    }
-    // error
-    return false;
-  }
+  BrotliDecoder decoder;
+  return decoder.decompressFull(input, maxDecompressedBytes, decoderChunkSize, out);
 }
+
+bool BrotliDecoder::decompressFull(std::string_view input, std::size_t maxDecompressedBytes,
+                                   std::size_t decoderChunkSize, RawChars &out) {
+  BrotliStreamingContext ctx;
+  return ctx.decompressChunk(input, true, maxDecompressedBytes, decoderChunkSize, out);
+}
+
+std::unique_ptr<DecoderContext> BrotliDecoder::makeContext() { return std::make_unique<BrotliStreamingContext>(); }
 
 }  // namespace aeronet

--- a/aeronet/objects/src/zlib-decoder.cpp
+++ b/aeronet/objects/src/zlib-decoder.cpp
@@ -4,12 +4,17 @@
 #include <zlib.h>
 
 #include <cstddef>
+#include <memory>
+#include <stdexcept>
 #include <string_view>
 
+#include "aeronet/decoder.hpp"
 #include "aeronet/log.hpp"
 #include "aeronet/raw-chars.hpp"
 
 namespace aeronet {
+
+namespace {
 
 struct ZstreamInflateRAII {
   ZstreamInflateRAII() noexcept = default;
@@ -24,12 +29,72 @@ struct ZstreamInflateRAII {
   z_stream _strm{};
 };
 
+class ZlibStreamingContext final : public DecoderContext {
+ public:
+  explicit ZlibStreamingContext(bool isGzip) {
+    const int windowBits = isGzip ? (16 + MAX_WBITS) : MAX_WBITS;
+    if (inflateInit2(&_context._strm, windowBits) != Z_OK) {
+      throw std::runtime_error("ZlibStreamingContext - inflateInit2 failed");
+    }
+  }
+
+  bool decompressChunk(std::string_view chunk, bool finalChunk, std::size_t maxDecompressedBytes,
+                       std::size_t decoderChunkSize, RawChars &out) override {
+    if (_finished) {
+      return chunk.empty();
+    }
+    if (chunk.empty()) {
+      return finalChunk ? _finished : true;
+    }
+
+    auto &stream = _context._strm;
+
+    stream.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(chunk.data()));
+    stream.avail_in = static_cast<uInt>(chunk.size());
+
+    while (true) {
+      out.ensureAvailableCapacityExponential(decoderChunkSize);
+      stream.avail_out = static_cast<uInt>(out.availableCapacity());
+      stream.next_out = reinterpret_cast<unsigned char *>(out.data() + out.size());
+
+      const auto ret = inflate(&stream, Z_NO_FLUSH);
+      if (ret != Z_OK && ret != Z_STREAM_END) {
+        log::error("ZlibDecoder::Decompress - inflate failed with error {}", ret);
+        return false;
+      }
+      out.setSize(out.capacity() - stream.avail_out);
+      if (maxDecompressedBytes != 0 && stream.total_out > maxDecompressedBytes) {
+        return false;
+      }
+      if (ret == Z_STREAM_END) {
+        _finished = true;
+        return stream.avail_in == 0;
+      }
+      if (stream.avail_in == 0) {
+        return !finalChunk;
+      }
+    }
+  }
+
+ private:
+  ZstreamInflateRAII _context;
+  bool _finished{false};
+};
+
+}  // namespace
+
 bool ZlibDecoder::Decompress(std::string_view input, bool isGzip, std::size_t maxDecompressedBytes,
                              std::size_t decoderChunkSize, RawChars &out) {
+  ZlibDecoder decoder(isGzip);
+  return decoder.decompressFull(input, maxDecompressedBytes, decoderChunkSize, out);
+}
+
+bool ZlibDecoder::decompressFull(std::string_view input, std::size_t maxDecompressedBytes, std::size_t decoderChunkSize,
+                                 RawChars &out) {
   ZstreamInflateRAII strm;
 
   // windowBits: 16 + MAX_WBITS enables gzip decoding; MAX_WBITS alone for zlib; -MAX_WBITS raw deflate.
-  const int windowBits = isGzip ? (16 + MAX_WBITS) : MAX_WBITS;
+  const int windowBits = _isGzip ? (16 + MAX_WBITS) : MAX_WBITS;
   const auto ec = inflateInit2(&strm._strm, windowBits);
   if (ec != Z_OK) {
     log::error("ZlibDecoder::Decompress - inflateInit2 failed with error {}", ec);
@@ -44,7 +109,7 @@ bool ZlibDecoder::Decompress(std::string_view input, bool isGzip, std::size_t ma
     strm._strm.avail_out = static_cast<uInt>(out.availableCapacity());
     strm._strm.next_out = reinterpret_cast<unsigned char *>(out.data() + out.size());
 
-    const auto ret = inflate(&strm._strm, 0);
+    const auto ret = inflate(&strm._strm, Z_NO_FLUSH);
     if (ret != Z_OK && ret != Z_STREAM_END) {
       log::error("ZlibDecoder::Decompress - inflate failed with error {}", ret);
       return false;
@@ -54,12 +119,14 @@ bool ZlibDecoder::Decompress(std::string_view input, bool isGzip, std::size_t ma
       break;
     }
 
-    if (strm._strm.total_out >= maxDecompressedBytes) {
+    if (maxDecompressedBytes != 0 && strm._strm.total_out >= maxDecompressedBytes) {
       return false;  // size limit
     }
   }
 
   return true;
 }
+
+std::unique_ptr<DecoderContext> ZlibDecoder::makeContext() { return std::make_unique<ZlibStreamingContext>(_isGzip); }
 
 }  // namespace aeronet


### PR DESCRIPTION
Seamless change for the client. This is only a technical change, to be able to decompress `HttpRequest`'s body with streaming decoder instead of waiting for the full body before inflate.