### PR TITLE
feat: TLS phase 2 implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,8 @@ jobs:
           aeronet-multi \
           aeronet-sendfile \
           aeronet-static-example \
-          aeronet-tls-ktls
+          aeronet-tls-ktls \
+          aeronet-tls-session-tickets
 
       - name: Generate TLS certificate for ktls example
         run: |
@@ -344,6 +345,9 @@ jobs:
             
           run_server_and_curl tls "https://127.0.0.1:18443/" -k -- \
             "${EXAMPLE_DIR}/aeronet-tls-ktls" ${BUILD_DIR}/certs/server.crt ${BUILD_DIR}/certs/server.key 18443
+
+          run_server_and_curl tls-session-tickets "https://127.0.0.1:18444/" -k -- \
+            "${EXAMPLE_DIR}/aeronet-tls-session-tickets" ${BUILD_DIR}/certs/server.crt ${BUILD_DIR}/certs/server.key 18444
 
       - name: Verify markdown C/C++ examples (compile & link)
         run: |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ If you are evaluating the library, the feature highlights above plus the minimal
 | Keep‑Alive / Limits | ✔ | Header/body size, max requests per connection, idle timeout |
 | Compression (gzip/deflate/zstd/br) | ✔ | Flags opt‑in; q‑value negotiation; threshold; per‑response opt‑out |
 | Inbound body decompression | ✔ | Multi‑layer, safety guards, header removal |
-| TLS | ✔ (flag) | ALPN, mTLS (optional/required), timeouts, metrics |
+| TLS | ✔ (flag) | ALPN, mTLS, session tickets, KTLS sendfile, timeouts, metrics |
 | OpenTelemetry | ✔ (flag) | Distributed tracing spans, metrics counters (experimental) |
 | Async wrapper | ✔ | Background thread convenience |
 | Metrics hook | ✔ (alpha) | Per‑request basic stats |

--- a/aeronet/http/src/multipart-form-data.cpp
+++ b/aeronet/http/src/multipart-form-data.cpp
@@ -2,11 +2,16 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
+#include <functional>
 #include <iterator>
+#include <optional>
+#include <span>
 #include <string_view>
 
 #include "aeronet/http-constants.hpp"
 #include "aeronet/string-equal-ignore-case.hpp"
+#include "aeronet/vector.hpp"
 
 namespace aeronet {
 namespace {

--- a/aeronet/http/test/http-response-fuzz_test.cpp
+++ b/aeronet/http/test/http-response-fuzz_test.cpp
@@ -7,8 +7,10 @@
 #include <random>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
+#include "aeronet/http-header.hpp"
 #include "aeronet/http-response.hpp"
 #include "aeronet/http-status-code.hpp"
 

--- a/aeronet/http/test/multipart-form-data_test.cpp
+++ b/aeronet/http/test/multipart-form-data_test.cpp
@@ -4,6 +4,7 @@
 
 #include <initializer_list>
 #include <string>
+#include <string_view>
 
 namespace aeronet {
 namespace {
@@ -59,9 +60,9 @@ TEST(MultipartFormDataTest, ParsesTextAndFileParts) {
   const auto& filePart = form.parts()[1];
   EXPECT_EQ(filePart.name, "file");
   ASSERT_TRUE(filePart.filename.has_value());
-  EXPECT_EQ(*filePart.filename, "hello.txt");
+  EXPECT_EQ(filePart.filename.value_or(std::string_view{}), "hello.txt");
   ASSERT_TRUE(filePart.contentType.has_value());
-  EXPECT_EQ(*filePart.contentType, "text/plain");
+  EXPECT_EQ(filePart.contentType.value_or(std::string_view{}), "text/plain");
   EXPECT_EQ(filePart.value, "file-content");
   EXPECT_EQ(filePart.headerValueOrEmpty("Content-Type"), "text/plain");
 }
@@ -90,7 +91,7 @@ TEST(MultipartFormDataTest, QuotedBoundaryAndLookupByName) {
 
   auto allAlpha = form.parts("alpha");
   ASSERT_EQ(allAlpha.size(), 2);
-  EXPECT_EQ(allAlpha[1].get().filename.value(), "b.txt");
+  EXPECT_EQ(allAlpha[1].get().filename.value_or(std::string_view{}), "b.txt");
 }
 
 TEST(MultipartFormDataTest, PartLookupGracefullyHandlesMissingNames) {
@@ -131,9 +132,9 @@ TEST(MultipartFormDataTest, FilenameStarParameterIsHandled) {
   ASSERT_EQ(form.parts().size(), 1);
   const auto& part = form.parts()[0];
   ASSERT_TRUE(part.filename.has_value());
-  EXPECT_EQ(part.filename.value(), "sample.bin");
+  EXPECT_EQ(part.filename.value_or(std::string_view{}), "sample.bin");
   ASSERT_TRUE(part.contentType.has_value());
-  EXPECT_EQ(part.contentType.value(), "application/octet-stream");
+  EXPECT_EQ(part.contentType.value_or(std::string_view{}), "application/octet-stream");
 }
 
 TEST(MultipartFormDataTest, MissingBoundaryMakesFormInvalid) {

--- a/aeronet/main/include/aeronet/multi-http-server.hpp
+++ b/aeronet/main/include/aeronet/multi-http-server.hpp
@@ -8,6 +8,7 @@
 #include <stop_token>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/http-server.hpp"

--- a/aeronet/main/src/http-server-lifecycle.cpp
+++ b/aeronet/main/src/http-server-lifecycle.cpp
@@ -8,7 +8,6 @@
 #include <memory>
 #include <stdexcept>
 #include <stop_token>
-#include <string_view>
 #include <thread>
 #include <utility>
 
@@ -152,9 +151,7 @@ HttpServer& HttpServer::operator=(const HttpServer& other) {
     const bool wasInMulti = _isInMultiHttpServer;
     auto lifecycleTracker = _lifecycleTracker;
 
-    HttpServer copy(other);
-    using std::swap;
-    swap(*this, copy);
+    *this = HttpServer(other);
 
     _isInMultiHttpServer = wasInMulti;
     _lifecycleTracker = std::move(lifecycleTracker);

--- a/aeronet/main/src/multi-http-server.cpp
+++ b/aeronet/main/src/multi-http-server.cpp
@@ -17,7 +17,7 @@
 #include <thread>
 #include <utility>
 
-#include "aeronet/errno_throw.hpp"
+#include "aeronet/errno-throw.hpp"
 #include "aeronet/http-server-config.hpp"
 #include "aeronet/http-server.hpp"
 #include "aeronet/log.hpp"

--- a/aeronet/objects/src/accept-encoding-negotiation.cpp
+++ b/aeronet/objects/src/accept-encoding-negotiation.cpp
@@ -44,7 +44,7 @@ constexpr bool IsEncodingEnabled(Encoding enc) {
   }
 }
 
-constexpr std::string_view trim(std::string_view sv) {
+constexpr std::string_view Trim(std::string_view sv) {
   while (!sv.empty() && kWhitespace.find(sv.front()) != std::string_view::npos) {
     sv.remove_prefix(1);
   }
@@ -55,14 +55,14 @@ constexpr std::string_view trim(std::string_view sv) {
 }
 
 // Parse q-value within a token (portion including parameters); never throws.
-double parseQ(std::string_view token) {
+double ParseQ(std::string_view token) {
   auto scPos = token.find(';');
   if (scPos == std::string_view::npos) {
     return 1.0;
   }
   std::string_view params = token.substr(scPos + 1);
   while (!params.empty()) {
-    params = trim(params);
+    params = Trim(params);
     auto nextSemi = params.find(';');
     std::string_view param = nextSemi == std::string_view::npos ? params : params.substr(0, nextSemi);
     if (nextSemi == std::string_view::npos) {
@@ -107,7 +107,7 @@ struct Sup {
 };
 
 template <std::size_t... I>
-consteval auto makeSupported(std::index_sequence<I...> /*unused*/) {
+consteval auto MakeSupported(std::index_sequence<I...> /*unused*/) {
   return std::array<Sup, sizeof...(I)>{{{GetEncodingStr(static_cast<Encoding>(I)), static_cast<Encoding>(I)}...}};
 }
 
@@ -153,7 +153,7 @@ EncodingSelector::NegotiatedResult EncodingSelector::negotiateAcceptEncoding(std
     return ret;
   }
 
-  static constexpr auto kSupportedEncodings = makeSupported(std::make_index_sequence<kNbContentEncodings>{});
+  static constexpr auto kSupportedEncodings = MakeSupported(std::make_index_sequence<kNbContentEncodings>{});
 
   struct ParsedToken {
     std::string_view name;
@@ -174,13 +174,13 @@ EncodingSelector::NegotiatedResult EncodingSelector::negotiateAcceptEncoding(std
   double identityQ = 0.0;
   for (auto part : acceptEncoding | std::views::split(',')) {
     std::string_view raw{&*part.begin(), static_cast<std::size_t>(std::ranges::distance(part))};
-    raw = trim(raw);
+    raw = Trim(raw);
     if (raw.empty()) {
       continue;
     }
     auto sc = raw.find(';');
-    std::string_view name = trim(sc == std::string_view::npos ? raw : raw.substr(0, sc));
-    double quality = parseQ(raw);
+    std::string_view name = Trim(sc == std::string_view::npos ? raw : raw.substr(0, sc));
+    double quality = ParseQ(raw);
     if (CaseInsensitiveEqual(name, "*")) {
       sawWildcard = true;
       wildcardQ = quality;

--- a/aeronet/objects/test/http-server-config_test.cpp
+++ b/aeronet/objects/test/http-server-config_test.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <limits>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "aeronet/http-header.hpp"

--- a/aeronet/sys/CMakeLists.txt
+++ b/aeronet/sys/CMakeLists.txt
@@ -31,6 +31,12 @@ AeronetAddUnitTest(
 )
 
 AeronetAddUnitTest(
+    errno-throw_test
+    test/errno-throw_test.cpp
+)
+
+
+AeronetAddUnitTest(
     event-fd_test
     test/event-fd_test.cpp
     LIBRARIES

--- a/aeronet/sys/include/aeronet/errno-throw.hpp
+++ b/aeronet/sys/include/aeronet/errno-throw.hpp
@@ -2,7 +2,6 @@
 
 #include <cerrno>
 #include <format>
-#include <string>
 #include <string_view>
 #include <system_error>
 
@@ -16,8 +15,7 @@ template <typename... Args>
   std::error_code ec(savedErr, std::generic_category());
   // std::format may throw std::format_error; allow it to propagate — it's acceptable
   // because this is typically called during unrecoverable system failures.
-  const std::string msg = std::vformat(fmt, std::make_format_args(std::forward<Args>(args)...));
-  throw std::system_error(ec, msg);
+  throw std::system_error(ec, std::vformat(fmt, std::make_format_args(std::forward<Args>(args)...)));
 }
 
 }  // namespace aeronet

--- a/aeronet/sys/src/event-fd.cpp
+++ b/aeronet/sys/src/event-fd.cpp
@@ -6,7 +6,7 @@
 #include <cstring>
 
 #include "aeronet/base-fd.hpp"
-#include "aeronet/errno_throw.hpp"
+#include "aeronet/errno-throw.hpp"
 #include "aeronet/log.hpp"
 
 namespace aeronet {

--- a/aeronet/sys/src/event-loop.cpp
+++ b/aeronet/sys/src/event-loop.cpp
@@ -15,7 +15,7 @@
 #include <utility>
 
 #include "aeronet/base-fd.hpp"
-#include "aeronet/errno_throw.hpp"
+#include "aeronet/errno-throw.hpp"
 #include "aeronet/event.hpp"
 #include "aeronet/log.hpp"
 #include "aeronet/timedef.hpp"

--- a/aeronet/sys/src/socket.cpp
+++ b/aeronet/sys/src/socket.cpp
@@ -11,7 +11,7 @@
 #include <stdexcept>
 
 #include "aeronet/base-fd.hpp"
-#include "aeronet/errno_throw.hpp"
+#include "aeronet/errno-throw.hpp"
 #include "aeronet/log.hpp"
 
 namespace aeronet {

--- a/aeronet/sys/test/errno-throw_test.cpp
+++ b/aeronet/sys/test/errno-throw_test.cpp
@@ -1,0 +1,27 @@
+#include "aeronet/errno-throw.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <string>
+#include <system_error>
+
+namespace aeronet {
+
+TEST(ErrnoThrow, ThrowsSystemErrorWithErrno) {
+  try {
+    // Simulate a system call failure by setting errno
+    errno = ENOENT;  // No such file or directory
+    int fd = 42;
+    throw_errno("Test error with code {}", fd);
+    FAIL() << "Expected std::system_error to be thrown";
+  } catch (const std::system_error& e) {
+    EXPECT_EQ(e.code().value(), ENOENT);
+    EXPECT_EQ(e.code().category(), std::generic_category());
+    EXPECT_EQ(e.what(), std::string("Test error with code 42: No such file or directory"));
+  } catch (...) {
+    FAIL() << "Expected std::system_error, but caught different exception";
+  }
+}
+
+}  // namespace aeronet

--- a/aeronet/tech/test/ipow_test.cpp
+++ b/aeronet/tech/test/ipow_test.cpp
@@ -10,6 +10,10 @@ TEST(MathHelpers, PowerPositiveBase) {
   EXPECT_EQ(ipow(1, 0), 1);
   EXPECT_EQ(ipow(1, 23), 1);
   EXPECT_EQ(ipow(1, 24), 1);
+  EXPECT_EQ(ipow(2, 24), 16777216);
+  EXPECT_EQ(ipow(2, 63), 0);
+  EXPECT_EQ(ipow(1, 100), 1);
+  EXPECT_EQ(ipow(2, 100), 0);  // overflow case
   EXPECT_EQ(ipow(3, 2), 9);
   EXPECT_EQ(ipow(4, 3), 64);
   EXPECT_EQ(ipow(17, 5), 1419857);
@@ -25,6 +29,8 @@ TEST(MathHelpers, PowerNegativeBase) {
   EXPECT_EQ(ipow(-1, 3), -1);
   EXPECT_EQ(ipow(-1, 32), 1);
   EXPECT_EQ(ipow(-1, 33), -1);
+  EXPECT_EQ(ipow(-1, 100), 1);
+  EXPECT_EQ(ipow(-1, 101), -1);
   EXPECT_EQ(ipow(-2, 1), -2);
   EXPECT_EQ(ipow(-3, 3), -27);
   EXPECT_EQ(ipow(-23, 13), -504036361936467383LL);

--- a/aeronet/test_support/full/include/aeronet/test_tls_client.hpp
+++ b/aeronet/test_support/full/include/aeronet/test_tls_client.hpp
@@ -28,10 +28,12 @@ namespace aeronet::test {
 class TlsClient {
  public:
   struct Options {
-    std::vector<std::string> alpn;  // e.g. {"http/1.1"}
-    bool verifyPeer{false};         // off for self-signed tests
-    std::string clientCertPem;      // optional client cert (mTLS)
-    std::string clientKeyPem;       // optional client key (mTLS)
+    std::vector<std::string> alpn;     // e.g. {"http/1.1"}
+    bool verifyPeer{false};            // off for self-signed tests
+    std::string clientCertPem;         // optional client cert (mTLS)
+    std::string clientKeyPem;          // optional client key (mTLS)
+    std::string trustedServerCertPem;  // optional PEM added to trust store when verifyPeer=true
+    std::string serverName;            // optional SNI/Host name override
   };
 
   // Constructor without custom options.
@@ -67,6 +69,7 @@ class TlsClient {
   void init();
 
   void loadClientCertKey(SSL_CTX* ctx);
+  void loadTrustedServerCert(SSL_CTX* ctx);
 
   // Wait for socket to be ready for reading or writing.
   // events: POLLIN for readable, POLLOUT for writable

--- a/aeronet/test_support/full/src/otlp_test_collector.cpp
+++ b/aeronet/test_support/full/src/otlp_test_collector.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "aeronet/base-fd.hpp"
-#include "aeronet/errno_throw.hpp"
+#include "aeronet/errno-throw.hpp"
 #include "aeronet/log.hpp"
 #include "aeronet/string-equal-ignore-case.hpp"
 #include "aeronet/test_util.hpp"

--- a/aeronet/test_support/full/src/test_util.cpp
+++ b/aeronet/test_support/full/src/test_util.cpp
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include "aeronet/base-fd.hpp"
-#include "aeronet/errno_throw.hpp"
+#include "aeronet/errno-throw.hpp"
 #include "aeronet/http-constants.hpp"
 #include "aeronet/http-status-code.hpp"
 #include "aeronet/log.hpp"

--- a/aeronet/tls/CMakeLists.txt
+++ b/aeronet/tls/CMakeLists.txt
@@ -32,3 +32,13 @@ AeronetAddUnitTest(
     aeronet_tls
     aeronet_test_support
 )
+
+AeronetAddUnitTest(
+    tls-ticket-key-store_test
+    src/tls-ticket-key-store.cpp
+    test/tls-ticket-key-store_test.cpp
+    LIBRARIES
+    aeronet_objects
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)

--- a/aeronet/tls/include/aeronet/tls-ticket-key-store.hpp
+++ b/aeronet/tls/include/aeronet/tls-ticket-key-store.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <openssl/types.h>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <span>
+
+#include "aeronet/tls-config.hpp"
+#include "aeronet/vector.hpp"
+
+namespace aeronet {
+
+// Thread-safe store of TLS session ticket keys shared across HttpServer instances (and
+// across MultiHttpServer workers). Provides automatic rotation for randomly generated keys
+// and supports injecting deterministic key material from configuration.
+class TlsTicketKeyStore {
+ public:
+  TlsTicketKeyStore(std::chrono::seconds lifetime, std::uint32_t maxKeys);
+
+  // Replace internal key material with the provided static keys (first entry is primary).
+  // Supplying at least one key automatically enables session tickets even if auto-rotation
+  // is disabled. Keys are truncated to the configured maxKeys.
+  void loadStaticKeys(std::span<const TLSConfig::SessionTicketKey> keys);
+
+  // Entry point used by the OpenSSL session ticket callback (EVP variant for OpenSSL 3.0+).
+  // When enc==1 a new ticket is issued (populate keyName/iv and initialize cipher/MAC contexts).
+  // When enc==0 the ticket must be decrypted using the matching keyName.
+  int processTicket(unsigned char keyName[16], unsigned char* iv, int ivLen, EVP_CIPHER_CTX* cctx, EVP_MAC_CTX* mctx,
+                    int enc);
+
+ private:
+  struct KeyMaterial {
+    using Part = std::array<unsigned char, 16>;
+
+    auto data() {
+      static_assert(TLSConfig::kSessionTicketKeySize == 3U * sizeof(Part), "Session ticket key size mismatch");
+      return std::span<unsigned char, TLSConfig::kSessionTicketKeySize>{name.data(), TLSConfig::kSessionTicketKeySize};
+    }
+
+    Part name;
+    Part hmacKey;
+    Part aesKey;
+    std::chrono::steady_clock::time_point created;
+  };
+
+  static KeyMaterial GenerateRandomKeyUnlocked();
+  void rotateIfNeededUnlocked();
+  const KeyMaterial* findKeyUnlocked(const unsigned char keyName[16]) const;
+
+  std::chrono::seconds _lifetime;
+  std::uint32_t _maxKeys;
+  bool _autoRotate{true};
+  mutable std::mutex _mutex;
+  vector<KeyMaterial> _keys;
+};
+
+}  // namespace aeronet

--- a/aeronet/tls/src/tls-context.cpp
+++ b/aeronet/tls/src/tls-context.cpp
@@ -9,18 +9,31 @@
 #include <openssl/x509.h>      // X509_free, X509_get_subject_name, X509_NAME_oneline
 #include <openssl/x509_vfy.h>  // X509_STORE_add_cert
 
+#include <cassert>
+#include <cctype>
 #include <cstddef>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <numeric>
+#include <span>
 #include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
 
 #include "aeronet/raw-bytes.hpp"
+#include "aeronet/raw-chars.hpp"
 #include "aeronet/tls-config.hpp"
 #include "aeronet/tls-raii.hpp"
+#include "aeronet/tls-ticket-key-store.hpp"
+#include "aeronet/toupperlower.hpp"
 
 namespace aeronet {
 namespace {
+void ApplyCipherPolicy(SSL_CTX* ctx, const TLSConfig& cfg);
+void AttachTicketStore(SSL_CTX* ctx, const std::shared_ptr<TlsTicketKeyStore>& store);
+
 int parseTlsVersion(TLSConfig::Version ver) {
   if (ver == TLSConfig::TLS_1_2) {
     return TLS1_2_VERSION;
@@ -32,6 +45,214 @@ int parseTlsVersion(TLSConfig::Version ver) {
 #endif
   return 0;  // unknown / not set
 }
+
+std::string NormalizeServerName(std::string_view host) {
+  std::string normalized(host);
+  for (char& ch : normalized) {
+    ch = tolower(ch);
+  }
+  return normalized;
+}
+
+bool MatchesSniPattern(std::string_view pattern, bool wildcard, std::string_view serverName) {
+  if (!wildcard) {
+    return serverName == pattern;
+  }
+  if (serverName.size() <= pattern.size() - 2) {
+    return false;
+  }
+  const std::string_view suffix = pattern.substr(1);  // drop '*'
+  return serverName.ends_with(suffix.substr(1));
+}
+
+void LoadCertificateAndKey(SSL_CTX* ctx, std::string_view certPem, std::string_view keyPem, const char* certFilePath,
+                           const char* keyFilePath) {
+  if (!certPem.empty() && !keyPem.empty()) {
+    auto certBio = makeMemBio(certPem.data(), static_cast<int>(certPem.size()));
+    auto keyBio = makeMemBio(keyPem.data(), static_cast<int>(keyPem.size()));
+    if (!certBio || !keyBio) {
+      throw std::runtime_error("Failed to allocate BIO for in-memory cert/key");
+    }
+    X509Ptr certX509(::PEM_read_bio_X509(certBio.get(), nullptr, nullptr, nullptr), ::X509_free);
+    PKeyPtr pkey(::PEM_read_bio_PrivateKey(keyBio.get(), nullptr, nullptr, nullptr), ::EVP_PKEY_free);
+    if (!certX509 || !pkey) {
+      throw std::runtime_error("Failed to parse in-memory certificate/key");
+    }
+    if (::SSL_CTX_use_certificate(ctx, certX509.get()) != 1) {
+      throw std::runtime_error("Failed to use in-memory certificate");
+    }
+    if (::SSL_CTX_use_PrivateKey(ctx, pkey.get()) != 1) {
+      throw std::runtime_error("Failed to use in-memory private key");
+    }
+  } else {
+    if (certFilePath == nullptr || keyFilePath == nullptr) {
+      throw std::runtime_error("Certificate or key file path missing");
+    }
+    if (::SSL_CTX_use_certificate_file(ctx, certFilePath, SSL_FILETYPE_PEM) != 1) {
+      throw std::runtime_error("Failed to load certificate");
+    }
+    if (::SSL_CTX_use_PrivateKey_file(ctx, keyFilePath, SSL_FILETYPE_PEM) != 1) {
+      throw std::runtime_error("Failed to load private key");
+    }
+  }
+
+  if (::SSL_CTX_check_private_key(ctx) != 1) {
+    throw std::runtime_error("Private key check failed");
+  }
+}
+
+void ConfigureContextOptions(SSL_CTX* ctx, const TLSConfig& cfg) {
+  if (cfg.disableCompression) {
+    ::SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION);
+  }
+#if defined(AERONET_ENABLE_KTLS) && defined(SSL_OP_ENABLE_KTLS)
+  if (cfg.ktlsMode != TLSConfig::KtlsMode::Disabled) {
+    ::SSL_CTX_set_options(ctx, SSL_OP_ENABLE_KTLS);
+  }
+#endif
+  if (cfg.cipherPolicy != TLSConfig::CipherPolicy::Default) {
+    ApplyCipherPolicy(ctx, cfg);
+  } else if (!cfg.cipherList().empty()) {
+    if (::SSL_CTX_set_cipher_list(ctx, cfg.cipherListCstrView().c_str()) != 1) {
+      throw std::runtime_error("Failed to set cipher list");
+    }
+  }
+}
+
+void ConfigureProtocolBounds(SSL_CTX* ctx, const TLSConfig& cfg) {
+  if (cfg.minVersion != TLSConfig::Version{}) {
+    int mv = parseTlsVersion(cfg.minVersion);
+    if (mv == 0 || ::SSL_CTX_set_min_proto_version(ctx, mv) != 1) {
+      throw std::runtime_error("Failed to set minimum TLS version");
+    }
+  }
+  if (cfg.maxVersion != TLSConfig::Version{}) {
+    int Mv = parseTlsVersion(cfg.maxVersion);
+    if (Mv == 0 || ::SSL_CTX_set_max_proto_version(ctx, Mv) != 1) {
+      throw std::runtime_error("Failed to set maximum TLS version");
+    }
+  }
+}
+
+void ConfigureClientVerification(SSL_CTX* ctx, const TLSConfig& cfg) {
+  if (!cfg.requestClientCert) {
+    return;
+  }
+  int verifyMode = SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE;
+  if (cfg.requireClientCert) {
+    verifyMode |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+  }
+  ::SSL_CTX_set_verify(ctx, verifyMode, nullptr);
+  for (std::string_view pem : cfg.trustedClientCertsPem()) {
+    if (pem.empty()) {
+      throw std::runtime_error("Empty trusted client certificate PEM provided");
+    }
+    auto cbio = makeMemBio(pem.data(), static_cast<int>(pem.size()));
+    if (!cbio) {
+      throw std::runtime_error("Failed to alloc BIO for client trust cert");
+    }
+    X509Ptr cx(::PEM_read_bio_X509(cbio.get(), nullptr, nullptr, nullptr), ::X509_free);
+    if (!cx) {
+      throw std::runtime_error("Failed to parse trusted client certificate");
+    }
+    if (::SSL_CTX_get_cert_store(ctx) == nullptr) {
+      throw std::runtime_error("No cert store available in SSL_CTX");
+    }
+    if (::X509_STORE_add_cert(::SSL_CTX_get_cert_store(ctx), cx.get()) != 1) {
+      throw std::runtime_error("Failed to add trusted client certificate to store");
+    }
+  }
+}
+
+void ConfigureSessionTickets(SSL_CTX* ctx, const TLSConfig& cfg,
+                             const std::shared_ptr<TlsTicketKeyStore>& ticketStore) {
+  if (!cfg.sessionTickets.enabled) {
+    ::SSL_CTX_set_options(ctx, SSL_OP_NO_TICKET);
+    return;
+  }
+  ::SSL_CTX_clear_options(ctx, SSL_OP_NO_TICKET);
+  if (ticketStore) {
+    AttachTicketStore(ctx, ticketStore);
+  }
+}
+
+const char* CipherPolicyTls13(TLSConfig::CipherPolicy policy) {
+  switch (policy) {
+    case TLSConfig::CipherPolicy::Modern:
+    case TLSConfig::CipherPolicy::Compatibility:
+      return "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256";
+    case TLSConfig::CipherPolicy::Legacy:
+      return "TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256";
+    default:
+      return nullptr;
+  }
+}
+
+const char* CipherPolicyTls12(TLSConfig::CipherPolicy policy) {
+  switch (policy) {
+    case TLSConfig::CipherPolicy::Modern:
+      return "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:"
+             "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:"
+             "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256";
+    case TLSConfig::CipherPolicy::Compatibility:
+      return "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:"
+             "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:"
+             "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:"
+             "ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256";
+    case TLSConfig::CipherPolicy::Legacy:
+      return "ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:AES256-SHA:AES128-SHA";
+    default:
+      return nullptr;
+  }
+}
+
+void ApplyCipherPolicy(SSL_CTX* ctx, const TLSConfig& cfg) {
+  if (cfg.cipherPolicy == TLSConfig::CipherPolicy::Default) {
+    return;
+  }
+  if (const char* suites13 = CipherPolicyTls13(cfg.cipherPolicy)) {
+    if (::SSL_CTX_set_ciphersuites(ctx, suites13) != 1) {
+      throw std::runtime_error("Failed to set TLS 1.3 cipher suites");
+    }
+  }
+  if (const char* suites12 = CipherPolicyTls12(cfg.cipherPolicy)) {
+    if (::SSL_CTX_set_cipher_list(ctx, suites12) != 1) {
+      throw std::runtime_error("Failed to set TLS cipher list");
+    }
+  }
+}
+
+int TicketStoreIndex() {
+  static std::once_flag flag;
+  static int index = 0;
+  std::call_once(flag, [] { index = ::SSL_CTX_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr); });
+  return index;
+}
+
+TlsTicketKeyStore* GetTicketStore(SSL_CTX* ctx) {
+  if (ctx == nullptr) {
+    return nullptr;
+  }
+  return static_cast<TlsTicketKeyStore*>(::SSL_CTX_get_ex_data(ctx, TicketStoreIndex()));
+}
+
+int SessionTicketCallback(SSL* ssl, unsigned char* keyName, unsigned char* iv, EVP_CIPHER_CTX* cctx, EVP_MAC_CTX* mctx,
+                          int enc) {
+  SSL_CTX* sslCtx = ::SSL_get_SSL_CTX(ssl);
+  auto* storePtr = GetTicketStore(sslCtx);
+  if (storePtr == nullptr) {
+    return 0;
+  }
+  return storePtr->processTicket(keyName, iv, EVP_MAX_IV_LENGTH, cctx, mctx, enc);
+}
+
+void AttachTicketStore(SSL_CTX* ctx, const std::shared_ptr<TlsTicketKeyStore>& store) {
+  if (ctx == nullptr || store == nullptr) {
+    return;
+  }
+  ::SSL_CTX_set_ex_data(ctx, TicketStoreIndex(), store.get());
+  ::SSL_CTX_set_tlsext_ticket_key_evp_cb(ctx, &SessionTicketCallback);
+}
 }  // namespace
 
 void TlsContext::CtxDel::operator()(ssl_ctx_st* ctxPtr) const noexcept {
@@ -41,38 +262,18 @@ void TlsContext::CtxDel::operator()(ssl_ctx_st* ctxPtr) const noexcept {
 
 TlsContext::~TlsContext() = default;
 
-TlsContext::TlsContext(const TLSConfig& cfg, TlsMetricsExternal* metrics) : _ctx(::SSL_CTX_new(TLS_server_method())) {
+TlsContext::TlsContext(const TLSConfig& cfg, TlsMetricsExternal* metrics,
+                       std::shared_ptr<TlsTicketKeyStore> ticketKeyStore)
+    : _ctx(::SSL_CTX_new(TLS_server_method())), _ticketKeyStore(std::move(ticketKeyStore)) {
   if (!_ctx) {
     throw std::runtime_error("SSL_CTX_new failed");
   }
   auto* raw = reinterpret_cast<SSL_CTX*>(_ctx.get());
-#if defined(AERONET_ENABLE_KTLS) && defined(SSL_OP_ENABLE_KTLS)
-  if (cfg.ktlsMode != TLSConfig::KtlsMode::Disabled) {
-    ::SSL_CTX_set_options(raw, SSL_OP_ENABLE_KTLS);
-  }
-#endif
-  if (!cfg.cipherList().empty()) {
-    if (::SSL_CTX_set_cipher_list(raw, cfg.cipherListCstrView().c_str()) != 1) {
-      throw std::runtime_error("Failed to set cipher list");
-    }
-  }
-  // Protocol version bounds if provided
-  if (cfg.minVersion != TLSConfig::Version{}) {
-    int mv = parseTlsVersion(cfg.minVersion);
-    if (mv == 0 || ::SSL_CTX_set_min_proto_version(raw, mv) != 1) {
-      throw std::runtime_error("Failed to set minimum TLS version");
-    }
-  }
-  if (cfg.maxVersion != TLSConfig::Version{}) {
-    int Mv = parseTlsVersion(cfg.maxVersion);
-    if (Mv == 0 || ::SSL_CTX_set_max_proto_version(raw, Mv) != 1) {
-      throw std::runtime_error("Failed to set maximum TLS version");
-    }
-  }
+  ConfigureContextOptions(raw, cfg);
+  ConfigureProtocolBounds(raw, cfg);
   std::string_view certPem = cfg.certPem();
   std::string_view keyPem = cfg.keyPem();
   if (!certPem.empty() && !keyPem.empty()) {
-    // In-memory load path
     auto certBio = makeMemBio(certPem.data(), static_cast<int>(certPem.size()));
     auto keyBio = makeMemBio(keyPem.data(), static_cast<int>(keyPem.size()));
     if (!certBio || !keyBio) {
@@ -89,7 +290,6 @@ TlsContext::TlsContext(const TLSConfig& cfg, TlsMetricsExternal* metrics) : _ctx
     if (::SSL_CTX_use_PrivateKey(raw, pkey.get()) != 1) {
       throw std::runtime_error("Failed to use in-memory private key");
     }
-    // SSL_CTX increases ref counts internally; unique_ptr releases will free local if ref counts allow.
   } else {
     if (::SSL_CTX_use_certificate_file(raw, cfg.certFileCstrView().c_str(), SSL_FILETYPE_PEM) != 1) {
       throw std::runtime_error("Failed to load certificate");
@@ -101,37 +301,9 @@ TlsContext::TlsContext(const TLSConfig& cfg, TlsMetricsExternal* metrics) : _ctx
   if (::SSL_CTX_check_private_key(raw) != 1) {
     throw std::runtime_error("Private key check failed");
   }
-  if (cfg.requestClientCert) {
-    int verifyMode = SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE;
-    if (cfg.requireClientCert) {
-      verifyMode |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
-    }
-    ::SSL_CTX_set_verify(raw, verifyMode, nullptr);
-    // Load any in-memory trusted client certs (appended to default store). For test / pinning usage.
-    for (std::string_view pem : cfg.trustedClientCertsPem()) {
-      if (pem.empty()) {
-        throw std::runtime_error("Empty trusted client certificate PEM provided");
-      }
-      auto cbio = makeMemBio(pem.data(), static_cast<int>(pem.size()));
-      if (!cbio) {
-        throw std::runtime_error("Failed to alloc BIO for client trust cert");
-      }
-      X509Ptr cx(::PEM_read_bio_X509(cbio.get(), nullptr, nullptr, nullptr), ::X509_free);
-      if (!cx) {
-        throw std::runtime_error("Failed to parse trusted client certificate");
-      }
-      if (::SSL_CTX_get_cert_store(raw) == nullptr) {
-        throw std::runtime_error("No cert store available in SSL_CTX");
-      }
-      if (::X509_STORE_add_cert(::SSL_CTX_get_cert_store(raw), cx.get()) != 1) {
-        throw std::runtime_error("Failed to add trusted client certificate to store");
-      }
-    }
-  }
+  ConfigureClientVerification(raw, cfg);
 
-  // ALPN setup
   auto alpnProtocols = cfg.alpnProtocols();
-
   std::size_t wireLen = std::accumulate(alpnProtocols.begin(), alpnProtocols.end(), std::size_t{0},
                                         [](std::size_t sum, const auto& proto) { return sum + 1UL + proto.size(); });
   if (wireLen != 0) {
@@ -140,40 +312,105 @@ TlsContext::TlsContext(const TLSConfig& cfg, TlsMetricsExternal* metrics) : _ctx
       _alpnData->wire.unchecked_push_back(static_cast<std::byte>(proto.size()));
       _alpnData->wire.unchecked_append(reinterpret_cast<const std::byte*>(proto.data()), proto.size());
     }
-    ::SSL_CTX_set_alpn_select_cb(
-        raw,
-        []([[maybe_unused]] SSL* ssl, const unsigned char** out, unsigned char* outlen, const unsigned char* in,
-           unsigned int inlen, void* arg) -> int {
-          auto* data = reinterpret_cast<AlpnData*>(arg);
-          const unsigned char* ptr = reinterpret_cast<const unsigned char*>(data->wire.data());
-          unsigned int prefLen = static_cast<unsigned int>(data->wire.size());
-          unsigned int prefIndex = 0;
-          while (prefIndex < prefLen) {
-            unsigned int len = ptr[prefIndex];
-            const unsigned char* val = ptr + prefIndex + 1;
-            unsigned int clientIndex = 0;
-            while (clientIndex < inlen) {
-              unsigned int clen = in[clientIndex];
-              const unsigned char* cval = in + clientIndex + 1;
-              if (clen == len && std::memcmp(val, cval, len) == 0) {
-                *out = val;
-                *outlen = static_cast<unsigned char>(len);
-                return SSL_TLSEXT_ERR_OK;
-              }
-              clientIndex += 1 + clen;
-            }
-            prefIndex += 1 + len;
-          }
-          if (data->mustMatch) {
-            if (data->metrics) {
-              ++data->metrics->alpnStrictMismatches;
-            }
-            return SSL_TLSEXT_ERR_ALERT_FATAL;
-          }
-          return SSL_TLSEXT_ERR_NOACK;
-        },
-        _alpnData.get());
+    ::SSL_CTX_set_alpn_select_cb(raw, &TlsContext::SelectAlpn, _alpnData.get());
   }
+
+  if (cfg.sessionTickets.enabled) {
+    if (!_ticketKeyStore) {
+      _ticketKeyStore = std::make_shared<TlsTicketKeyStore>(cfg.sessionTickets.lifetime, cfg.sessionTickets.maxKeys);
+    }
+    if (!cfg.sessionTicketKeys().empty()) {
+      _ticketKeyStore->loadStaticKeys(cfg.sessionTicketKeys());
+    }
+  }
+  ConfigureSessionTickets(raw, cfg, _ticketKeyStore);
+
+  const auto& sniCerts = cfg.sniCertificates();
+  if (!sniCerts.empty()) {
+    _sniRoutes = std::make_unique<SniRoutes>(std::make_unique<SniRoute[]>(sniCerts.size()), sniCerts.size());
+    SniRoute* pRoute = _sniRoutes->routes.get();
+    for (const auto& entry : sniCerts) {
+      CtxPtr routeCtx{reinterpret_cast<ssl_ctx_st*>(::SSL_CTX_new(TLS_server_method()))};
+      if (!routeCtx) {
+        throw std::runtime_error("SSL_CTX_new failed for SNI certificate");
+      }
+      auto* routeRaw = reinterpret_cast<SSL_CTX*>(routeCtx.get());
+      ConfigureContextOptions(routeRaw, cfg);
+      ConfigureProtocolBounds(routeRaw, cfg);
+      if (entry.certPem().empty()) {
+        LoadCertificateAndKey(routeRaw, std::string_view{}, std::string_view{}, entry.certFileCstrView().c_str(),
+                              entry.keyFileCstrView().c_str());
+      } else {
+        LoadCertificateAndKey(routeRaw, entry.certPem(), entry.keyPem(), nullptr, nullptr);
+      }
+      ConfigureClientVerification(routeRaw, cfg);
+      if (_alpnData != nullptr) {
+        ::SSL_CTX_set_alpn_select_cb(routeRaw, &TlsContext::SelectAlpn, _alpnData.get());
+      }
+      ConfigureSessionTickets(routeRaw, cfg, _ticketKeyStore);
+      *pRoute = SniRoute(RawChars(entry.pattern()), entry.isWildcard, std::move(routeCtx));
+      ++pRoute;
+    }
+    ::SSL_CTX_set_tlsext_servername_arg(raw, _sniRoutes.get());
+    ::SSL_CTX_set_tlsext_servername_callback(raw, &TlsContext::SelectSniRoute);
+  }
+}
+
+int TlsContext::SelectAlpn([[maybe_unused]] SSL* ssl, const unsigned char** out, unsigned char* outlen,
+                           const unsigned char* in, unsigned int inlen, void* arg) {
+  auto* data = reinterpret_cast<AlpnData*>(arg);
+  assert(data != nullptr && !data->wire.empty());
+  const unsigned char* ptr = reinterpret_cast<const unsigned char*>(data->wire.data());
+  const unsigned int prefLen = static_cast<unsigned int>(data->wire.size());
+  for (unsigned int prefIndex = 0; prefIndex < prefLen;) {
+    const unsigned char* val = ptr + prefIndex + 1;
+    const unsigned int len = ptr[prefIndex];
+    for (unsigned int clientIndex = 0; clientIndex < inlen;) {
+      unsigned int clen = in[clientIndex];
+      const unsigned char* cval = in + clientIndex + 1;
+      if (clen == len && std::memcmp(val, cval, len) == 0) {
+        *out = val;
+        *outlen = static_cast<unsigned char>(len);
+        return SSL_TLSEXT_ERR_OK;
+      }
+      clientIndex += 1 + clen;
+    }
+    prefIndex += 1 + len;
+  }
+  if (data->mustMatch) {
+    if (data->metrics != nullptr) {
+      ++data->metrics->alpnStrictMismatches;
+    }
+    return SSL_TLSEXT_ERR_ALERT_FATAL;
+  }
+  return SSL_TLSEXT_ERR_NOACK;
+}
+
+int TlsContext::SelectSniRoute(SSL* ssl, int* alert, void* arg) {
+  auto& routes = *reinterpret_cast<SniRoutes*>(arg);
+  std::span<SniRoute> routeSpan(routes.routes.get(), routes.nbRoutes);
+  assert(arg != nullptr && !routeSpan.empty());
+  const char* serverName = ::SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+  if (serverName == nullptr) {
+    return SSL_TLSEXT_ERR_NOACK;
+  }
+  std::string normalized = NormalizeServerName(serverName);
+  for (auto& route : routeSpan) {
+    if (MatchesSniPattern(route.pattern, route.wildcard, normalized)) {
+      auto* nextCtx = reinterpret_cast<SSL_CTX*>(route.ctx.get());
+      if (nextCtx == nullptr) {
+        break;
+      }
+      if (::SSL_set_SSL_CTX(ssl, nextCtx) != nullptr) {
+        return SSL_TLSEXT_ERR_OK;
+      }
+      if (alert != nullptr) {
+        *alert = SSL_AD_INTERNAL_ERROR;
+      }
+      return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+  }
+  return SSL_TLSEXT_ERR_NOACK;
 }
 
 }  // namespace aeronet

--- a/aeronet/tls/src/tls-ticket-key-store.cpp
+++ b/aeronet/tls/src/tls-ticket-key-store.cpp
@@ -1,0 +1,129 @@
+#include "aeronet/tls-ticket-key-store.hpp"
+
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/params.h>
+#include <openssl/rand.h>
+#include <openssl/types.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <span>
+#include <stdexcept>
+
+#include "aeronet/log.hpp"
+#include "aeronet/tls-config.hpp"
+
+namespace aeronet {
+
+TlsTicketKeyStore::TlsTicketKeyStore(std::chrono::seconds lifetime, std::uint32_t maxKeys)
+    : _lifetime(lifetime), _maxKeys(std::max<std::uint32_t>(1, maxKeys)) {}
+
+void TlsTicketKeyStore::loadStaticKeys(std::span<const TLSConfig::SessionTicketKey> keys) {
+  std::scoped_lock<std::mutex> lock(_mutex);
+  _keys.clear();
+  _autoRotate = keys.empty();
+  auto now = std::chrono::steady_clock::now();
+  for (const auto& raw : keys) {
+    KeyMaterial& mat = _keys.emplace_back();
+    const auto matData = mat.data();
+    const auto* ptr = reinterpret_cast<const unsigned char*>(raw.data());
+    std::memcpy(matData.data(), ptr, matData.size());
+    mat.created = now;
+
+    if (_keys.size() == _maxKeys) {
+      log::warn("Ignoring excess {} TLS session ticket keys beyond configured maxKeys={}", _keys.size() - _maxKeys,
+                _maxKeys);
+      break;
+    }
+  }
+  if (_autoRotate) {
+    _keys.emplace_back(GenerateRandomKeyUnlocked());
+  }
+}
+
+namespace {
+
+bool InitMacContext(EVP_MAC_CTX* mctx, const unsigned char* hmacKey, std::size_t hmacKeyLen) {
+  static const OSSL_PARAM params[]{
+      OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, const_cast<char*>("SHA256"), 0),
+      OSSL_PARAM_construct_end()};
+  if (EVP_MAC_CTX_set_params(mctx, params) != 1) {
+    return false;
+  }
+  return EVP_MAC_init(mctx, hmacKey, hmacKeyLen, nullptr) == 1;
+}
+
+}  // namespace
+
+int TlsTicketKeyStore::processTicket(unsigned char keyName[16], unsigned char* iv, int ivLen, EVP_CIPHER_CTX* cctx,
+                                     EVP_MAC_CTX* mctx, int enc) {
+  std::scoped_lock<std::mutex> lock(_mutex);
+  if (enc == 1) {
+    rotateIfNeededUnlocked();
+    if (_keys.empty()) {
+      _keys.emplace_back(GenerateRandomKeyUnlocked());
+    }
+    auto& key = _keys.front();
+    if (RAND_bytes(iv, ivLen) != 1) {
+      return -1;
+    }
+    std::memcpy(keyName, key.name.data(), key.name.size());
+    if (EVP_EncryptInit_ex(cctx, EVP_aes_128_cbc(), nullptr, key.aesKey.data(), iv) != 1) {
+      return -1;
+    }
+    if (!InitMacContext(mctx, key.hmacKey.data(), key.hmacKey.size())) {
+      return -1;
+    }
+    return 1;
+  }
+
+  const KeyMaterial* key = findKeyUnlocked(keyName);
+  if (key == nullptr) {
+    return 0;  // trigger full handshake
+  }
+  if (EVP_DecryptInit_ex(cctx, EVP_aes_128_cbc(), nullptr, key->aesKey.data(), iv) != 1) {
+    return -1;
+  }
+  if (!InitMacContext(mctx, key->hmacKey.data(), key->hmacKey.size())) {
+    return -1;
+  }
+  return 1;
+}
+
+TlsTicketKeyStore::KeyMaterial TlsTicketKeyStore::GenerateRandomKeyUnlocked() {
+  KeyMaterial key;
+  auto data = key.data();
+  if (RAND_bytes(data.data(), static_cast<int>(data.size())) != 1) {
+    throw std::runtime_error("RAND_bytes failed generating ticket");
+  }
+  key.created = std::chrono::steady_clock::now();
+  return key;
+}
+
+void TlsTicketKeyStore::rotateIfNeededUnlocked() {
+  if (_autoRotate && _lifetime.count() > 0) {
+    if (_keys.empty() || std::chrono::steady_clock::now() - _keys.front().created >= _lifetime) {
+      _keys.emplace(_keys.begin(), GenerateRandomKeyUnlocked());
+      if (_keys.size() > _maxKeys) {
+        _keys.pop_back();
+      }
+    }
+  }
+}
+
+const TlsTicketKeyStore::KeyMaterial* TlsTicketKeyStore::findKeyUnlocked(const unsigned char keyName[16]) const {
+  for (const auto& mat : _keys) {
+    if (std::memcmp(mat.name.data(), keyName, mat.name.size()) == 0) {
+      return &mat;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace aeronet

--- a/aeronet/tls/test/tls-ticket-key-store_test.cpp
+++ b/aeronet/tls/test/tls-ticket-key-store_test.cpp
@@ -1,0 +1,289 @@
+#include "aeronet/tls-ticket-key-store.hpp"
+
+#include <gtest/gtest.h>
+#include <openssl/evp.h>
+#include <openssl/types.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <thread>
+
+#include "aeronet/tls-config.hpp"
+
+namespace aeronet {
+
+TEST(TlsTicketKeyStoreTest, ProcessTicketIssuesAndDecrypts) {
+  // Create a ticket store with a single static key.
+  TlsTicketKeyStore ticketStore(std::chrono::seconds(60), 2);
+  std::array<TLSConfig::SessionTicketKey, 1> staticKeys;
+  for (std::size_t idx = 0; idx < staticKeys[0].size(); ++idx) {
+    staticKeys[0][idx] = static_cast<std::byte>(idx);
+  }
+  ticketStore.loadStaticKeys(staticKeys);
+
+  // Set up cipher context and MAC context for testing.
+  std::array<unsigned char, 16> keyName{};
+  std::array<unsigned char, EVP_MAX_IV_LENGTH> iv{};
+
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> cipherCtx{::EVP_CIPHER_CTX_new(),
+                                                                              &::EVP_CIPHER_CTX_free};
+  ASSERT_NE(cipherCtx.get(), nullptr);
+
+  EVP_MAC* mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  std::unique_ptr<EVP_MAC_CTX, decltype(&::EVP_MAC_CTX_free)> macCtx{::EVP_MAC_CTX_new(mac), &::EVP_MAC_CTX_free};
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  // Test issuing a new ticket (enc = 1).
+  int issueRc = ticketStore.processTicket(keyName.data(), iv.data(), static_cast<int>(iv.size()), cipherCtx.get(),
+                                          macCtx.get(), 1);
+  EXPECT_EQ(issueRc, 1);
+
+  // Reset cipher context for decryption test.
+  ::EVP_CIPHER_CTX_reset(cipherCtx.get());
+
+  // Recreate MAC context for decryption.
+  mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  macCtx.reset(::EVP_MAC_CTX_new(mac));
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  // Test decrypting with the same key name (enc = 0).
+  int decryptRc = ticketStore.processTicket(keyName.data(), iv.data(), static_cast<int>(iv.size()), cipherCtx.get(),
+                                            macCtx.get(), 0);
+  EXPECT_EQ(decryptRc, 1);
+}
+
+TEST(TlsTicketKeyStoreTest, RotateExceedsMaxKeysPopsBack) {
+  // Use a short lifetime and maxKeys=1 to force rotation and pop_back behavior.
+  TlsTicketKeyStore ticketStore(std::chrono::seconds(1), 1);
+
+  // Ensure auto-rotate mode (no static keys loaded)
+  ticketStore.loadStaticKeys(std::span<const TLSConfig::SessionTicketKey>{});
+
+  std::array<unsigned char, 16> firstKeyName{};
+  std::array<unsigned char, EVP_MAX_IV_LENGTH> iv{};
+
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> cipherCtx{::EVP_CIPHER_CTX_new(),
+                                                                              &::EVP_CIPHER_CTX_free};
+  ASSERT_NE(cipherCtx.get(), nullptr);
+
+  EVP_MAC* mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  std::unique_ptr<EVP_MAC_CTX, decltype(&::EVP_MAC_CTX_free)> macCtx{::EVP_MAC_CTX_new(mac), &::EVP_MAC_CTX_free};
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  // Issue first ticket (creates initial key)
+  int rc1 = ticketStore.processTicket(firstKeyName.data(), iv.data(), static_cast<int>(iv.size()), cipherCtx.get(),
+                                      macCtx.get(), 1);
+  EXPECT_EQ(rc1, 1);
+
+  // Wait for lifetime to expire so the next issuance rotates and pushes a new key.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+
+  // Issue second ticket (rotation should occur and, because maxKeys==1, pop_back should remove the first key)
+  std::array<unsigned char, 16> secondKeyName{};
+  std::array<unsigned char, EVP_MAX_IV_LENGTH> iv2{};
+  ::EVP_CIPHER_CTX_reset(cipherCtx.get());
+  mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  macCtx.reset(::EVP_MAC_CTX_new(mac));
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  int rc2 = ticketStore.processTicket(secondKeyName.data(), iv2.data(), static_cast<int>(iv2.size()), cipherCtx.get(),
+                                      macCtx.get(), 1);
+  EXPECT_EQ(rc2, 1);
+
+  // Attempt to decrypt with the original first key name: should return 0 (unknown key) because it was popped.
+  ::EVP_CIPHER_CTX_reset(cipherCtx.get());
+  mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  macCtx.reset(::EVP_MAC_CTX_new(mac));
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  int decryptRc = ticketStore.processTicket(firstKeyName.data(), iv.data(), static_cast<int>(iv.size()),
+                                            cipherCtx.get(), macCtx.get(), 0);
+  EXPECT_EQ(decryptRc, 0);
+}
+
+TEST(TlsTicketKeyStoreTest, LoadStaticKeysMaxKeysLimit) {
+  // Test that loading more keys than maxKeys truncates at the limit (covers line 31 break)
+  TlsTicketKeyStore ticketStore(std::chrono::seconds(60), 2);
+
+  // Create 5 keys but store only has maxKeys=2
+  std::array<TLSConfig::SessionTicketKey, 5> staticKeys{};
+  for (std::size_t keyIdx = 0; keyIdx < staticKeys.size(); ++keyIdx) {
+    for (std::size_t byteIdx = 0; byteIdx < staticKeys[keyIdx].size(); ++byteIdx) {
+      staticKeys[keyIdx][byteIdx] = static_cast<std::byte>((keyIdx * 100) + byteIdx);
+    }
+  }
+
+  ticketStore.loadStaticKeys(staticKeys);
+
+  // Verify we can issue/decrypt with the first key (which should be loaded)
+  std::array<unsigned char, 16> keyName{};
+  std::array<unsigned char, EVP_MAX_IV_LENGTH> iv{};
+
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> cipherCtx{::EVP_CIPHER_CTX_new(),
+                                                                              &::EVP_CIPHER_CTX_free};
+  ASSERT_NE(cipherCtx.get(), nullptr);
+
+  EVP_MAC* mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  std::unique_ptr<EVP_MAC_CTX, decltype(&::EVP_MAC_CTX_free)> macCtx{::EVP_MAC_CTX_new(mac), &::EVP_MAC_CTX_free};
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  // Issue should succeed (key was loaded)
+  int issueRc = ticketStore.processTicket(keyName.data(), iv.data(), static_cast<int>(iv.size()), cipherCtx.get(),
+                                          macCtx.get(), 1);
+  EXPECT_EQ(issueRc, 1);
+}
+
+TEST(TlsTicketKeyStoreTest, ProcessTicketUnknownKeyReturns0) {
+  // Test decryption with an unknown key name returns 0 (covers line 55)
+  TlsTicketKeyStore ticketStore(std::chrono::seconds(60), 2);
+
+  std::array<TLSConfig::SessionTicketKey, 1> staticKeys{};
+  for (std::size_t idx = 0; idx < staticKeys[0].size(); ++idx) {
+    staticKeys[0][idx] = static_cast<std::byte>(idx);
+  }
+  ticketStore.loadStaticKeys(staticKeys);
+
+  // Use a completely different key name that won't match any stored key
+  std::array<unsigned char, 16> unknownKeyName{};
+  std::ranges::fill(unknownKeyName, 0xFF);
+  std::array<unsigned char, EVP_MAX_IV_LENGTH> iv{};
+
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> cipherCtx{::EVP_CIPHER_CTX_new(),
+                                                                              &::EVP_CIPHER_CTX_free};
+  ASSERT_NE(cipherCtx.get(), nullptr);
+
+  EVP_MAC* mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  std::unique_ptr<EVP_MAC_CTX, decltype(&::EVP_MAC_CTX_free)> macCtx{::EVP_MAC_CTX_new(mac), &::EVP_MAC_CTX_free};
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  // Decrypt with unknown key should return 0 (key not found)
+  int decryptRc = ticketStore.processTicket(unknownKeyName.data(), iv.data(), static_cast<int>(iv.size()),
+                                            cipherCtx.get(), macCtx.get(), 0);
+  EXPECT_EQ(decryptRc, 0);
+}
+
+TEST(TlsTicketKeyStoreTest, ProcessTicketShouldGenerateRandomKeyIfNoKeys) {
+  TlsTicketKeyStore ticketStore({}, 0);
+
+  std::array<unsigned char, 16> unknownKeyName;
+  std::ranges::fill(unknownKeyName, 0xFF);
+  std::array<unsigned char, EVP_MAX_IV_LENGTH> iv{};
+
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> cipherCtx{::EVP_CIPHER_CTX_new(),
+                                                                              &::EVP_CIPHER_CTX_free};
+  ASSERT_NE(cipherCtx.get(), nullptr);
+
+  EVP_MAC* mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  std::unique_ptr<EVP_MAC_CTX, decltype(&::EVP_MAC_CTX_free)> macCtx{::EVP_MAC_CTX_new(mac), &::EVP_MAC_CTX_free};
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  // Decrypt with unknown key should return 0 (key not found)
+  int decryptRc = ticketStore.processTicket(unknownKeyName.data(), iv.data(), static_cast<int>(iv.size()),
+                                            cipherCtx.get(), macCtx.get(), 1);
+  EXPECT_EQ(decryptRc, 1);
+}
+
+TEST(TlsTicketKeyStoreTest, LoadStaticKeysEmptyGeneratesKey) {
+  // Covers tls-ticket-key-store.cpp lines 43-44: auto-rotate generates key when loadStaticKeys with empty
+  TlsTicketKeyStore ticketStore(std::chrono::seconds(60), 2);
+
+  // Load empty keys - should trigger auto-rotate to generate a key
+  std::span<const TLSConfig::SessionTicketKey> emptyKeys;
+  ticketStore.loadStaticKeys(emptyKeys);
+
+  // Now try to process a ticket - should work because a key was auto-generated
+  std::array<unsigned char, 16> keyName{};
+  std::array<unsigned char, EVP_MAX_IV_LENGTH> iv{};
+
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> cipherCtx{::EVP_CIPHER_CTX_new(),
+                                                                              &::EVP_CIPHER_CTX_free};
+  ASSERT_NE(cipherCtx.get(), nullptr);
+
+  EVP_MAC* mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  std::unique_ptr<EVP_MAC_CTX, decltype(&::EVP_MAC_CTX_free)> macCtx{::EVP_MAC_CTX_new(mac), &::EVP_MAC_CTX_free};
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  int rc = ticketStore.processTicket(keyName.data(), iv.data(), static_cast<int>(iv.size()), cipherCtx.get(),
+                                     macCtx.get(), 1);
+  EXPECT_EQ(rc, 1);
+}
+
+TEST(TlsTicketKeyStoreTest, AutoRotateGeneratesKeyWhenEmpty) {
+  // Covers line 43-44: auto-rotate generates a key when processTicket called with empty store
+  // The store auto-rotates when _autoRotate is true (default) and keys are empty
+  TlsTicketKeyStore ticketStore(std::chrono::seconds(60), 2);
+
+  // Don't load any keys - the store should auto-generate on first processTicket
+
+  std::array<unsigned char, 16> keyName{};
+  std::array<unsigned char, EVP_MAX_IV_LENGTH> iv{};
+
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> cipherCtx{::EVP_CIPHER_CTX_new(),
+                                                                              &::EVP_CIPHER_CTX_free};
+  ASSERT_NE(cipherCtx.get(), nullptr);
+
+  EVP_MAC* mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  std::unique_ptr<EVP_MAC_CTX, decltype(&::EVP_MAC_CTX_free)> macCtx{::EVP_MAC_CTX_new(mac), &::EVP_MAC_CTX_free};
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  // Issue should succeed because auto-rotate creates a key
+  int issueRc = ticketStore.processTicket(keyName.data(), iv.data(), static_cast<int>(iv.size()), cipherCtx.get(),
+                                          macCtx.get(), 1);
+  EXPECT_EQ(issueRc, 1);
+}
+
+TEST(TlsTicketKeyStoreTest, RotateAfterLifetimeExpires) {
+  // Covers the rotation path when key lifetime expires
+  TlsTicketKeyStore ticketStore(std::chrono::seconds(0), 2);  // 0 lifetime = immediate rotation
+
+  std::array<TLSConfig::SessionTicketKey, 1> staticKeys{};
+  for (std::size_t idx = 0; idx < staticKeys[0].size(); ++idx) {
+    staticKeys[0][idx] = static_cast<std::byte>(idx);
+  }
+  ticketStore.loadStaticKeys(staticKeys);
+
+  std::array<unsigned char, 16> keyName{};
+  std::array<unsigned char, EVP_MAX_IV_LENGTH> iv{};
+
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)> cipherCtx{::EVP_CIPHER_CTX_new(),
+                                                                              &::EVP_CIPHER_CTX_free};
+  ASSERT_NE(cipherCtx.get(), nullptr);
+
+  EVP_MAC* mac = ::EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  ASSERT_NE(mac, nullptr);
+  std::unique_ptr<EVP_MAC_CTX, decltype(&::EVP_MAC_CTX_free)> macCtx{::EVP_MAC_CTX_new(mac), &::EVP_MAC_CTX_free};
+  ::EVP_MAC_free(mac);
+  ASSERT_NE(macCtx.get(), nullptr);
+
+  // Issue a ticket - with lifetime=0, this will trigger rotation on each call
+  int issueRc = ticketStore.processTicket(keyName.data(), iv.data(), static_cast<int>(iv.size()), cipherCtx.get(),
+                                          macCtx.get(), 1);
+  EXPECT_EQ(issueRc, 1);
+}
+
+}  // namespace aeronet

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,3 +20,8 @@ if (AERONET_ENABLE_OPENSSL AND AERONET_ENABLE_KTLS)
 	AeronetAddProjectExecutable(aeronet-tls-ktls tls-ktls.cpp)
 	target_link_libraries(aeronet-tls-ktls PRIVATE aeronet)
 endif()
+
+if (AERONET_ENABLE_OPENSSL)
+	AeronetAddProjectExecutable(aeronet-tls-session-tickets tls-session-tickets.cpp)
+	target_link_libraries(aeronet-tls-session-tickets PRIVATE aeronet)
+endif()

--- a/examples/tls-session-tickets.cpp
+++ b/examples/tls-session-tickets.cpp
@@ -1,0 +1,115 @@
+#include <aeronet/aeronet.hpp>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+#include <utility>
+
+using namespace aeronet;
+
+/// Example demonstrating TLS session ticket configuration.
+///
+/// Session tickets allow TLS session resumption without server-side session
+/// caches, enabling faster subsequent handshakes (0-RTT negotiation).
+///
+/// Test session resumption with OpenSSL s_client:
+///   # First connection (full handshake)
+///   openssl s_client -connect localhost:8443 -sess_out session.pem
+///
+///   # Second connection (resumed - look for "Reused, TLSv1.3")
+///   openssl s_client -connect localhost:8443 -sess_in session.pem
+
+int main(int argc, char** argv) {
+  if (argc < 3 || argc > 5) {
+    std::cerr << "Usage: " << argv[0] << " <cert.pem> <key.pem> [port] [--static-key]\n\n";
+    std::cerr << "Options:\n";
+    std::cerr << "  --static-key  Use a static session ticket key instead of auto-rotation\n";
+    return EXIT_FAILURE;
+  }
+
+  std::string certPath = argv[1];
+  std::string keyPath = argv[2];
+  uint16_t port = 8443;
+  bool useStaticKey = false;
+
+  for (int ii = 3; ii < argc; ++ii) {
+    std::string arg = argv[ii];
+    if (arg == "--static-key") {
+      useStaticKey = true;
+    } else {
+      port = static_cast<uint16_t>(std::stoi(arg));
+    }
+  }
+
+  aeronet::SignalHandler::Enable();
+
+  try {
+    aeronet::HttpServerConfig cfg;
+    cfg.withPort(port).withTlsCertKey(certPath, keyPath);
+
+    if (useStaticKey) {
+      // Static key mode: load a fixed key for session ticket encryption.
+      // This is useful for distributed deployments where multiple servers
+      // need to decrypt tickets issued by each other.
+      //
+      // In production, load this from a secrets manager or encrypted storage.
+      // Key must be exactly 48 bytes: 16B name + 16B AES + 16B HMAC.
+      aeronet::TLSConfig::SessionTicketKey staticKey;
+
+      // For demo purposes only - use RAND_bytes() or secure key storage in production
+      for (auto& bt : staticKey) {
+        bt = static_cast<std::byte>(std::rand() % 256);  // NOLINT - demo only
+      }
+
+      cfg.tls.withTlsSessionTicketKey(std::move(staticKey));  // Enables tickets + loads key
+      std::cout << "Session tickets enabled with static key (rotation disabled)\n";
+    } else {
+      // Automatic key rotation mode (recommended for single-server deployments).
+      // Keys are generated automatically and rotated at the configured interval.
+      cfg.tls.withTlsSessionTickets(true)
+          .withTlsSessionTicketLifetime(std::chrono::hours{2})
+          .withTlsSessionTicketMaxKeys(4);
+      std::cout << "Session tickets enabled with automatic key rotation\n";
+      std::cout << "  Key lifetime: 2 hours\n";
+      std::cout << "  Max keys in rotation: 4\n";
+    }
+
+    aeronet::Router router;
+    router.setDefault([](const aeronet::HttpRequest& req) {
+      aeronet::HttpResponse resp(aeronet::http::StatusCodeOK);
+      std::string body("Hello from aeronet with TLS session tickets!\n");
+      body += "Path: ";
+      body += req.path();
+      body.push_back('\n');
+      body += "TLS Version: ";
+      body += req.tlsVersion();
+      body.push_back('\n');
+      body += "Cipher: ";
+      body += req.tlsCipher();
+      body.push_back('\n');
+      resp.body(std::move(body));
+      return resp;
+    });
+
+    aeronet::HttpServer server(std::move(cfg), std::move(router));
+
+    std::cout << "Server listening on port " << port << "\n";
+    std::cout << "\nTest session resumption:\n";
+    std::cout << "  openssl s_client -connect localhost:" << port << " -sess_out session.pem\n";
+    std::cout << "  openssl s_client -connect localhost:" << port << " -sess_in session.pem\n";
+    std::cout << "  (Look for 'Reused, TLSv1.3' in output)\n\n";
+
+    server.run();
+
+    const auto stats = server.stats();
+    std::cout << "\nServer stats:\n";
+    std::cout << "  Total requests: " << stats.totalRequestsServed << '\n';
+    std::cout << "  TLS handshakes: " << stats.tlsHandshakesSucceeded << '\n';
+  } catch (const std::exception& ex) {
+    std::cerr << "Error: " << ex.what() << '\n';
+    return EXIT_FAILURE;
+  }
+}


### PR DESCRIPTION
- Session resumption (tickets) + resumed/full handshake counters
- SNI multi-cert routing (single listener, map host -> cert bundle)
- Failure reason counters + structured handshake event callback
- Cipher policy presets & disable compression flag
- Handshake concurrency limit + basic rate limiting
- MultiHttpServer shared ticket key support