### PR TITLE
chore: rename SmallRawChars into RawChars32, take size uint64_t as parameter

### DIFF
--- a/aeronet/main/include/aeronet/router.hpp
+++ b/aeronet/main/include/aeronet/router.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <amc/type_traits.hpp>
 #include <cstdint>
 #include <functional>
 #include <span>
@@ -270,9 +269,9 @@ class Router {
 
     bool operator==(const SegmentPart&) const noexcept = default;
 
-    using trivially_relocatable = amc::is_trivially_relocatable<SmallRawChars>::type;
+    using trivially_relocatable = std::true_type;
 
-    SmallRawChars literal;  // non empty when Kind::Literal
+    RawChars32 literal;  // non empty when Kind::Literal
   };
 
   struct CompiledSegment {
@@ -284,7 +283,7 @@ class Router {
 
     using trivially_relocatable = std::true_type;
 
-    SmallRawChars literal;      // non empty when Type::Literal
+    RawChars32 literal;         // non empty when Type::Literal
     vector<SegmentPart> parts;  // used when Type::Pattern
   };
 
@@ -307,13 +306,13 @@ class Router {
     RouteNode* child{nullptr};
   };
 
-  using RouteNodeMap = flat_hash_map<SmallRawChars, RouteNode*, std::hash<std::string_view>, std::equal_to<>>;
+  using RouteNodeMap = flat_hash_map<RawChars32, RouteNode*, std::hash<std::string_view>, std::equal_to<>>;
 
   struct RouteNode {
     // Return a human-readable pattern string reconstructed from the compiled route
     // e.g. "/users/{param}/files/*" or "<empty>" when no route present.
     // Prerequisite: pRoute should not be nullptr.
-    [[nodiscard]] SmallRawChars patternString() const;
+    [[nodiscard]] RawChars32 patternString() const;
 
     RouteNodeMap literalChildren;
     vector<DynamicEdge> dynamicChildren;

--- a/aeronet/main/src/http-response-dispatch.cpp
+++ b/aeronet/main/src/http-response-dispatch.cpp
@@ -43,7 +43,7 @@ SingleHttpServer::LoopAction SingleHttpServer::processSpecialMethods(ConnectionM
     case http::Method::OPTIONS: {
       // OPTIONS * request (target="*") should return an Allow header listing supported methods.
       const auto buildAllowHeader = [](http::MethodBmp mask) {
-        SmallRawChars allowValue;
+        RawChars32 allowValue;
         for (http::MethodIdx methodIdx = 0; methodIdx < http::kNbMethods; ++methodIdx) {
           if (!http::IsMethodIdxSet(mask, methodIdx)) {
             continue;

--- a/aeronet/objects/include/aeronet/dogstatsd.hpp
+++ b/aeronet/objects/include/aeronet/dogstatsd.hpp
@@ -49,7 +49,7 @@ class DogStatsD {
   void sendMetricMessage(std::string_view metric, std::string_view value, std::string_view typeSuffix,
                          const DogStatsDTags& tags) const noexcept;
 
-  SmallRawChars _ns;
+  RawChars32 _ns;
   BaseFd _fd;
 };
 

--- a/aeronet/objects/include/aeronet/http-header.hpp
+++ b/aeronet/objects/include/aeronet/http-header.hpp
@@ -32,7 +32,7 @@ class Header {
   [[nodiscard]] std::string_view raw() const noexcept { return _data; }
 
  private:
-  SmallRawChars _data;
+  RawChars32 _data;
   uint32_t _colonPos;
 };
 

--- a/aeronet/objects/include/aeronet/telemetry-config.hpp
+++ b/aeronet/objects/include/aeronet/telemetry-config.hpp
@@ -19,7 +19,7 @@ namespace aeronet {
 class TelemetryConfig {
  public:
   using HistogramBoundariesMap =
-      flat_hash_map<SmallRawChars, vector<double>, std::hash<std::string_view>, std::equal_to<>>;
+      flat_hash_map<RawChars32, vector<double>, std::hash<std::string_view>, std::equal_to<>>;
 
   void validate();
 

--- a/aeronet/objects/src/dogstatsd.cpp
+++ b/aeronet/objects/src/dogstatsd.cpp
@@ -52,7 +52,7 @@ DogStatsD::DogStatsD(std::string_view socketPath, std::string_view ns, std::chro
 
   uint32_t dotAppendSz = !ns.empty() && ns.back() != '.' ? 1U : 0U;
 
-  _ns.reserve(static_cast<uint32_t>(ns.size()) + dotAppendSz);
+  _ns.reserve(ns.size() + dotAppendSz);
   _ns.unchecked_append(ns);
   if (dotAppendSz != 0) {
     _ns.unchecked_push_back('.');

--- a/aeronet/objects/src/http-header.cpp
+++ b/aeronet/objects/src/http-header.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <stdexcept>
 #include <string_view>
 
@@ -16,16 +15,13 @@ namespace aeronet::http {
 Header::Header(std::string_view name, std::string_view value) : _colonPos(static_cast<uint32_t>(name.size())) {
   value = TrimOws(value);
   std::size_t totalSize = name.size() + HeaderSep.size() + value.size();
-  if (totalSize > static_cast<std::size_t>(std::numeric_limits<decltype(_data)::size_type>::max())) {
-    throw std::invalid_argument("HTTP header size exceeds maximum allowed");
-  }
   if (!IsValidHeaderName(name)) {
     throw std::invalid_argument("HTTP header name is invalid");
   }
   if (!IsValidHeaderValue(value)) {
     throw std::invalid_argument("HTTP header value is invalid");
   }
-  _data.reserve(static_cast<decltype(_data)::size_type>(totalSize));
+  _data.reserve(totalSize);
   _data.unchecked_append(name);
   _data.unchecked_append(HeaderSep);
   _data.unchecked_append(value);

--- a/aeronet/objects/src/telemetry-config.cpp
+++ b/aeronet/objects/src/telemetry-config.cpp
@@ -108,7 +108,7 @@ TelemetryConfig& TelemetryConfig::addHistogramBuckets(std::string_view name, std
         std::format("Histogram '{}' bucket boundaries not strictly increasing", std::string_view(name)));
   }
   const auto [it, inserted] =
-      _histogramBuckets.emplace(SmallRawChars{name}, vector<double>{boundaries.begin(), boundaries.end()});
+      _histogramBuckets.emplace(RawChars32{name}, vector<double>{boundaries.begin(), boundaries.end()});
   if (!inserted) {
     log::warn("Overwriting '{}' histogram bucket boundaries", name);
     it->second.assign_range(boundaries);

--- a/aeronet/tech/include/aeronet/internal/raw-bytes-base.hpp
+++ b/aeronet/tech/include/aeronet/internal/raw-bytes-base.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 #include <type_traits>
 
@@ -27,13 +28,18 @@ class RawBytesBase {
   static_assert(std::is_trivially_copyable_v<T> && sizeof(T) == 1);
   static_assert(std::is_unsigned_v<SizeType>, "RawBytesBase requires an unsigned size type");
 
+  // Constructs an empty buffer, without any allocated storage.
   RawBytesBase() noexcept = default;
 
-  explicit RawBytesBase(size_type capacity);
+  // Constructs a buffer with the specified capacity.
+  // Warning: unlike std::string or std::vector, the size is set to 0, not to capacity.
+  explicit RawBytesBase(uint64_t capacity);
 
+  // Constructs a buffer initialized with the specified data.
   explicit RawBytesBase(ViewType data);
 
-  RawBytesBase(const_pointer data, size_type sz);
+  // Constructs a buffer initialized with the specified data.
+  RawBytesBase(const_pointer data, uint64_t sz);
 
   RawBytesBase(const RawBytesBase &rhs);
   RawBytesBase(RawBytesBase &&rhs) noexcept;
@@ -43,55 +49,87 @@ class RawBytesBase {
 
   ~RawBytesBase();
 
-  void unchecked_append(const_pointer data, size_type sz);
+  // Appends data to the end of the buffer without checking capacity.
+  void unchecked_append(const_pointer data, uint64_t sz);
 
+  // Appends data to the end of the buffer without checking capacity.
   void unchecked_append(ViewType data);
 
-  void append(const_pointer data, size_type sz);
+  // Appends data to the end of the buffer, reallocating if necessary.
+  void append(const_pointer data, uint64_t sz);
 
+  // Appends data to the end of the buffer, reallocating if necessary.
   void append(ViewType data);
 
-  void unchecked_push_back(value_type byte) { _buf[_size++] = byte; }
+  // Appends a single byte to the end of the buffer without checking capacity.
+  void unchecked_push_back(value_type byte) noexcept { _buf[_size++] = byte; }
 
+  // Appends a single byte to the end of the buffer, reallocating if necessary.
   void push_back(value_type byte);
 
-  void assign(const_pointer data, size_type size);
+  // Assigns new data to the buffer, replacing its current contents.
+  void assign(const_pointer data, uint64_t size);
 
+  // Assigns new data to the buffer, replacing its current contents.
   void assign(ViewType data);
 
+  // Clears the buffer, setting its size to zero.
   void clear() noexcept { _size = 0; }
 
-  void erase_front(size_type n);
+  // Erases the first n bytes from the buffer.
+  void erase_front(size_type n) noexcept;
 
-  void setSize(size_type newSize) { _size = newSize; }
+  // Sets the size of the buffer.
+  void setSize(size_type newSize) noexcept { _size = newSize; }
 
-  void addSize(size_type delta) { _size += delta; }
+  // Increases the size of the buffer by delta.
+  void addSize(size_type delta) noexcept { _size += delta; }
 
+  // Returns the current size of the buffer.
   [[nodiscard]] size_type size() const noexcept { return _size; }
 
+  // Returns the current capacity of the buffer.
   [[nodiscard]] size_type capacity() const noexcept { return _capacity; }
 
+  // Returns the available capacity of the buffer.
   [[nodiscard]] size_type availableCapacity() const noexcept { return _capacity - _size; }
 
-  void reserve(size_type newCapacity);
+  // Reserves capacity for at least newCapacity bytes.
+  void reserve(uint64_t newCapacity);
 
-  void shrink_to_fit();
+  // Shrinks the capacity of the buffer to fit its current size.
+  // Frees memory completely if the buffer is empty.
+  void shrink_to_fit() noexcept;
 
-  void ensureAvailableCapacity(size_type availableCapacity);
+  // Ensures that the buffer has at least the specified available capacity.
+  void ensureAvailableCapacity(uint64_t availableCapacity);
 
-  void ensureAvailableCapacityExponential(size_type availableCapacity);
+  // Ensures that the buffer has at least the specified available capacity,
+  // growing the capacity exponentially.
+  void ensureAvailableCapacityExponential(uint64_t availableCapacity);
 
+  // Returns a pointer to the buffer data.
   [[nodiscard]] pointer data() noexcept { return _buf; }
+
+  // Returns a const pointer to the buffer data.
   [[nodiscard]] const_pointer data() const noexcept { return _buf; }
 
+  // Returns a const iterator to the beginning of the buffer.
   [[nodiscard]] iterator begin() noexcept { return _buf; }
+
+  // Returns a const iterator to the beginning of the buffer.
   [[nodiscard]] const_iterator begin() const noexcept { return _buf; }
 
+  // Returns a const iterator to the end of the buffer.
   [[nodiscard]] iterator end() noexcept { return _buf + _size; }
+
+  // Returns a const iterator to the end of the buffer.
   [[nodiscard]] const_iterator end() const noexcept { return _buf + _size; }
 
+  // Returns true if the buffer is empty.
   [[nodiscard]] bool empty() const noexcept { return _size == 0; }
 
+  // Swaps the contents of this buffer with another buffer.
   void swap(RawBytesBase &rhs) noexcept;
 
   value_type &operator[](size_type pos) { return _buf[pos]; }

--- a/aeronet/tech/include/aeronet/raw-chars.hpp
+++ b/aeronet/tech/include/aeronet/raw-chars.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <string_view>
 
@@ -9,10 +8,11 @@
 namespace aeronet {
 
 // A byte buffer specialized for character data.
-using RawChars = RawBytesBase<char, std::string_view, std::size_t>;
+// Uses std::string_view as view type and std::uint64_t as size type.
+using RawChars = RawBytesBase<char, std::string_view, std::uint64_t>;
 
-// A smaller version of RawChars using 32-bit size type for scenarios where memory usage matters.
+// A smaller version of RawChars using 32-bit size type for scenarios where memory footprint matters.
 // The maximum size is limited to 4 GiB in that case.
-using SmallRawChars = RawBytesBase<char, std::string_view, std::uint32_t>;
+using RawChars32 = RawBytesBase<char, std::string_view, std::uint32_t>;
 
 }  // namespace aeronet

--- a/aeronet/tech/test/raw-bytes_test.cpp
+++ b/aeronet/tech/test/raw-bytes_test.cpp
@@ -26,7 +26,7 @@ class RawBaseTest : public ::testing::Test {
   using List = typename std::list<T>;
 };
 
-using MyTypes = ::testing::Types<RawBytes, SmallRawChars, RawChars>;
+using MyTypes = ::testing::Types<RawBytes, RawChars32, RawChars>;
 TYPED_TEST_SUITE(RawBaseTest, MyTypes, );
 
 TYPED_TEST(RawBaseTest, DefaultConstructor) {
@@ -338,7 +338,7 @@ TYPED_TEST(RawBaseTest, CopyFromEmpty) {
 }
 
 TYPED_TEST(RawBaseTest, UncheckedAppendAndOverflowCheck) {
-  using RawT = TypeParam;
+  using RawT = RawChars32;
   using Type = typename RawT::value_type;
   using SizeType = typename RawT::size_type;
 


### PR DESCRIPTION
This allows for simpler client code, not needed to check for overflows that are now moved inside `RawChars32` implementation.