### PR TITLE
feat: replace Status + reason constructors with Status + body in HttpResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@
 - **Fast & predictable**: edge‑triggered reactor model, zero/low‑allocation hot paths and minimal copies, horizontal scaling with port reuse. In CI benchmarks `aeronet` ranks among the [fastest tested implementations](#performance-at-a-glance) across multiple realistic scenarios.
 - **Modular & opt‑in**: enable only the features you need at compile time to minimize binary size and dependencies
 - **Ergonomic**: easy API, automatic features (encoding, telemetry), RAII listener setup with sync / async server lifetime control, developer friendly with no hidden global state, no macros
-- **Configurable**: extensive dynamic configuration with reasonable defaults (principle of least surprise)
+- **Configurable**: extensive dynamic configuration with reasonable defaults (principle of least surprise), per path options and middleware helpers, run-time router / config updates
 - **Standards compliant**: HTTP/1.1, HTTP/2, WebSocket, Compression, Streaming, Trailers, TLS, CORS, Range & Conditional Requests, Static files, URL Decoding, multipart/form-data, etc.
-- **Cloud native**: Built-in Kubernetes-style health probes, opentelemetry support (metrics, tracing), dogstatsd support, perfect for micro-services
+- **Cloud native**: Built-in Kubernetes-style health probes, opentelemetry support (metrics, tracing) with built-in spans and metrics, dogstatsd support, perfect for micro-services
 
 ### Performance at a glance
 
-`aeronet` is designed to be **very fast**. In our automated [wrk](https://github.com/wg/wrk)-based benchmarks against other popular frameworks (run in CI against a fixed set of competitors such as [drogon](https://github.com/drogonframework/drogon), [pistache](https://github.com/pistacheio/pistache), a Rust Axum server, Java Undertow, Go and Python), `aeronet`:
+`aeronet` is designed to be **very fast**. In our automated [wrk](https://github.com/wg/wrk)-based benchmarks (HTTP/1.1 based) against other popular frameworks (run in CI against a fixed set of competitors such as [drogon](https://github.com/drogonframework/drogon), [pistache](https://github.com/pistacheio/pistache), a Rust Axum server, Java Undertow, Go and Python), `aeronet`:
 
 - Achieves the **highest requests/sec** in most scenarios
 - Consistently delivers **lower average latency** in those same scenarios
@@ -41,6 +41,7 @@ You can browse the latest rendered benchmark tables directly on GitHub Pages:
 ## Minimal Examples
 
 Spin up a basic HTTP server that responds on `/hello` in just a few lines. If you pass `0` as the port (or omit it), the kernel picks an ephemeral port which you can query immediately.
+**All code examples** in the `README` and the `FEATURES.md` files are guaranteed to compile as they are covered by a CI check.
 
 ### Immediate response
 
@@ -302,7 +303,7 @@ using namespace aeronet;
 
 int main() {
   Router router;
-  router.setDefault([](const HttpRequest&){ return HttpResponse(200, "OK").body("hi"); });
+  router.setDefault([](const HttpRequest&){ return HttpResponse(200).body("hi"); });
   SingleHttpServer srv(HttpServerConfig{}, std::move(router));
   // Launch in background thread and capture lifetime handle
   auto handle = srv.startDetached();
@@ -590,7 +591,7 @@ int main() {
   Router router;
   // Register application handlers as usual (optional)
   router.setPath(http::Method::GET, "/hello", [](const HttpRequest&){
-    return HttpResponse(200, "OK").body("hello\n");
+    return HttpResponse(200).body("hello\n");
   });
 
   SingleHttpServer server(std::move(cfg), std::move(router));
@@ -854,14 +855,14 @@ Example:
 ```cpp
 Router router;
 router.setPath(http::Method::GET | http::Method::PUT, "/hello", [](const HttpRequest&){
-  return HttpResponse(200, "OK").body("world");
+  return HttpResponse(200).body("world");
 });
 router.setPath(http::Method::POST, "/echo", [](const HttpRequest& req){
-  return HttpResponse(200, "OK").body(req.body());
+  return HttpResponse(200).body(req.body());
 });
 // Add another method later (merges method mask, replaces handler)
 router.setPath(http::Method::GET, "/echo", [](const HttpRequest& req){
-  return HttpResponse(200, "OK").body("Echo via GET");
+  return HttpResponse(200).body("Echo via GET");
 });
 ```
 

--- a/aeronet/http/include/aeronet/connection-state.hpp
+++ b/aeronet/http/include/aeronet/connection-state.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string_view>
 
 #include "aeronet/file-payload.hpp"
@@ -194,14 +195,13 @@ struct ConnectionState {
     AwaitReason awaitReason{AwaitReason::None};
     bool active{false};
     bool needsBody{false};
-    bool responsePending{false};
     bool isChunked{false};
     bool expectContinue{false};
     std::size_t consumedBytes{0};
     const CorsPolicy* corsPolicy{nullptr};
     const void* responseMiddleware{nullptr};
     std::size_t responseMiddlewareCount{0};
-    HttpResponse pendingResponse;
+    std::optional<HttpResponse> pendingResponse;
   } asyncState;
 };
 

--- a/aeronet/http/test/connection-state_test.cpp
+++ b/aeronet/http/test/connection-state_test.cpp
@@ -21,7 +21,9 @@
 #include <utility>
 
 #include "aeronet/base-fd.hpp"
+#include "aeronet/file-payload.hpp"
 #include "aeronet/file.hpp"
+#include "aeronet/http-response.hpp"
 #include "aeronet/http-status-code.hpp"
 #include "aeronet/sys-test-support.hpp"
 #include "aeronet/temp-file.hpp"
@@ -467,7 +469,6 @@ TEST(ConnectionStateAsyncStateTest, AsyncHandlerStateClearResetsState) {
   st.awaitReason = ConnectionState::AsyncHandlerState::AwaitReason::WaitingForBody;
   st.active = true;
   st.needsBody = true;
-  st.responsePending = true;
   st.isChunked = true;
   st.expectContinue = true;
   st.consumedBytes = 42;
@@ -483,16 +484,13 @@ TEST(ConnectionStateAsyncStateTest, AsyncHandlerStateClearResetsState) {
   EXPECT_EQ(st.awaitReason, ConnectionState::AsyncHandlerState::AwaitReason::None);
   EXPECT_FALSE(st.active);
   EXPECT_FALSE(st.needsBody);
-  EXPECT_FALSE(st.responsePending);
   EXPECT_FALSE(st.isChunked);
   EXPECT_FALSE(st.expectContinue);
   EXPECT_EQ(st.consumedBytes, 0U);
   EXPECT_EQ(st.corsPolicy, nullptr);
   EXPECT_EQ(st.responseMiddleware, nullptr);
   EXPECT_EQ(st.responseMiddlewareCount, 0U);
-  // pendingResponse should be default constructed; accept status 0 or OK depending on implementation
-  auto prStatus = st.pendingResponse.status();
-  EXPECT_TRUE(prStatus == static_cast<http::StatusCode>(0) || prStatus == http::StatusCodeOK);
+  EXPECT_FALSE(st.pendingResponse.has_value());
 }
 
 TEST(ConnectionStateAsyncStateTest, ClearDestroysNonNullHandle) {

--- a/aeronet/http/test/router_test.cpp
+++ b/aeronet/http/test/router_test.cpp
@@ -36,7 +36,7 @@ TEST_F(RouterTest, RegisterAndMatchNormalHandler) {
   bool called = false;
   router.setPath(http::Method::GET, "/hello", [&called](const HttpRequest &) {
     called = true;
-    return HttpResponse(http::StatusCodeOK, "OK");
+    return HttpResponse(http::StatusCodeOK);
   });
 
   auto res = router.match(http::Method::GET, "/hello");

--- a/aeronet/main/include/aeronet/aeronet.hpp
+++ b/aeronet/main/include/aeronet/aeronet.hpp
@@ -29,7 +29,7 @@
 //    int main() {
 //      Router router;
 //      router.setDefault([](const HttpRequest& req){
-//         return HttpResponse(200, "OK").body("hi\n");
+//         return HttpResponse(200, "hi\n");
 //      });
 //      SingleHttpServer server(HttpServerConfig{}.withPort(0), std::move(router));
 //      server.run();

--- a/aeronet/main/include/aeronet/http-response-writer.hpp
+++ b/aeronet/main/include/aeronet/http-response-writer.hpp
@@ -31,9 +31,6 @@ class HttpResponseWriter {
   // Replaces the status code. Must be a 3 digits integer.
   void status(http::StatusCode code);
 
-  // Convenience overload: set both status code and reason phrase in one call.
-  void status(http::StatusCode code, std::string_view reason);
-
   // Sets or replace the reason phrase for this instance.
   // Inserting empty reason is allowed.
   // If the data to be inserted references internal instance memory, the behavior is undefined.

--- a/aeronet/main/include/aeronet/single-http-server.hpp
+++ b/aeronet/main/include/aeronet/single-http-server.hpp
@@ -496,7 +496,7 @@ class SingleHttpServer {
   void resumeAsyncHandler(ConnectionMapIt cnxIt);
   void handleAsyncBodyProgress(ConnectionMapIt cnxIt);
   void onAsyncHandlerCompleted(ConnectionMapIt cnxIt);
-  bool tryFlushPendingAsyncResponse(ConnectionMapIt cnxIt);
+  void tryFlushPendingAsyncResponse(ConnectionMapIt cnxIt);
 
   [[nodiscard]] bool isInMultiHttpServer() const noexcept { return _lifecycleTracker.use_count() != 0; }
 

--- a/aeronet/main/src/http-response-writer.cpp
+++ b/aeronet/main/src/http-response-writer.cpp
@@ -56,12 +56,12 @@ void HttpResponseWriter::status(http::StatusCode code) {
   _fixedResponse.status(code);
 }
 
-void HttpResponseWriter::status(http::StatusCode code, std::string_view reason) {
+void HttpResponseWriter::reason(std::string_view reason) {
   if (_state != State::Opened) {
-    log::warn("Streaming: cannot set status after headers sent");
+    log::warn("Streaming: cannot set reason after headers sent");
     return;
   }
-  _fixedResponse.status(code, reason);
+  _fixedResponse.reason(reason);
 }
 
 void HttpResponseWriter::headerAddLine(std::string_view name, std::string_view value) {

--- a/aeronet/objects/include/aeronet/header-write.hpp
+++ b/aeronet/objects/include/aeronet/header-write.hpp
@@ -1,15 +1,19 @@
 #pragma once
 
+#include <cassert>
+#include <charconv>
+#include <concepts>
 #include <cstring>
 #include <string_view>
 
 #include "aeronet/http-constants.hpp"
+#include "aeronet/nchars.hpp"
 #include "aeronet/timedef.hpp"
 #include "aeronet/timestring.hpp"
 
 namespace aeronet {
 
-inline char *WriteHeader(char *insertPtr, std::string_view key, std::string_view value) {
+constexpr char *WriteHeader(char *insertPtr, std::string_view key, std::string_view value) {
   std::memcpy(insertPtr, key.data(), key.size());
   std::memcpy(insertPtr + key.size(), http::HeaderSep.data(), http::HeaderSep.size());
   if (!value.empty()) {
@@ -18,7 +22,17 @@ inline char *WriteHeader(char *insertPtr, std::string_view key, std::string_view
   return insertPtr + key.size() + http::HeaderSep.size() + value.size();
 }
 
-inline char *WriteCRLF(char *insertPtr) {
+constexpr char *WriteHeader(char *insertPtr, std::string_view key, std::integral auto value) {
+  std::memcpy(insertPtr, key.data(), key.size());
+  std::memcpy(insertPtr + key.size(), http::HeaderSep.data(), http::HeaderSep.size());
+  const auto valueSz = nchars(value);
+  insertPtr += key.size() + http::HeaderSep.size();
+  [[maybe_unused]] const auto result = std::to_chars(insertPtr, insertPtr + valueSz, value);
+  assert(result.ec == std::errc() && result.ptr == insertPtr + valueSz);
+  return insertPtr + valueSz;
+}
+
+constexpr char *WriteCRLF(char *insertPtr) {
   std::memcpy(insertPtr, http::CRLF.data(), http::CRLF.size());
   return insertPtr + http::CRLF.size();
 }
@@ -26,19 +40,27 @@ inline char *WriteCRLF(char *insertPtr) {
 // Write an HTTP header field to the given buffer, including a last CRLF.
 // Returns the pointer immediately after the last written byte.
 // Header key must not be empty, but header value may be empty.
-inline char *WriteHeaderCRLF(char *insertPtr, std::string_view key, std::string_view value) {
+constexpr char *WriteHeaderCRLF(char *insertPtr, std::string_view key, std::string_view value) {
+  return WriteCRLF(WriteHeader(insertPtr, key, value));
+}
+
+constexpr char *WriteHeaderCRLF(char *insertPtr, std::string_view key, std::integral auto value) {
   return WriteCRLF(WriteHeader(insertPtr, key, value));
 }
 
 // Same as above, but CRLF is first
-inline char *WriteCRLFHeader(char *insertPtr, std::string_view key, std::string_view value) {
+constexpr char *WriteCRLFHeader(char *insertPtr, std::string_view key, std::string_view value) {
+  return WriteHeader(WriteCRLF(insertPtr), key, value);
+}
+
+constexpr char *WriteCRLFHeader(char *insertPtr, std::string_view key, std::integral auto value) {
   return WriteHeader(WriteCRLF(insertPtr), key, value);
 }
 
 // Write a Date HTTP header field to the given buffer, including a last CRLF.
 // Returns the pointer immediately after the last written byte.
 // Given buffer requires a size of at least "Date".size() + HeaderSep.size() + kRFC7231DateStrLen + CRLF.size().
-inline char *WriteCRLFDateHeader(char *insertPtr, SysTimePoint tp) {
+constexpr char *WriteCRLFDateHeader(char *insertPtr, SysTimePoint tp) {
   insertPtr = WriteCRLF(insertPtr);
   std::memcpy(insertPtr, http::Date.data(), http::Date.size());
   std::memcpy(insertPtr + http::Date.size(), http::HeaderSep.data(), http::HeaderSep.size());

--- a/aeronet/objects/src/accept-encoding-negotiation.cpp
+++ b/aeronet/objects/src/accept-encoding-negotiation.cpp
@@ -14,7 +14,6 @@
 #include <string_view>
 #include <system_error>
 #include <type_traits>
-#include <utility>
 
 #include "aeronet/compression-config.hpp"
 #include "aeronet/encoding.hpp"

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -278,16 +278,16 @@ Short examples:
 ```cpp
 // Move a std::string into the response
 std::string big /* = generate_large_string() */;
-HttpResponse(200, "OK").body(std::move(big), "application/octet-stream");
+HttpResponse(200).body(std::move(big), "application/octet-stream");
 
 // Move a vector<char>
 std::vector<char> v /* = read_file_bytes(path) */;
-HttpResponse(200, "OK").body(std::move(v), "application/octet-stream");
+HttpResponse(200).body(std::move(v), "application/octet-stream");
 
 // Move a unique_ptr<char[]> for raw blob ownership
 std::unique_ptr<char[]> blob /* = load_blob() */;
 std::size_t blobSize /* = known size */;
-HttpResponse(200, "OK").body(std::move(blob), blobSize, "application/octet-stream");
+HttpResponse(200).body(std::move(blob), blobSize, "application/octet-stream");
 ```
 
 These patterns hand ownership to the server without duplicating the payload, enabling efficient zero-copy handoff
@@ -472,7 +472,7 @@ HttpServerConfig cfg; cfg.withCompression(c);
 
 Router router;
 router.setDefault([](const HttpRequest&) {
-  return HttpResponse(200, "OK").body(std::string(1024,'A'));
+  return HttpResponse(200).body(std::string(1024,'A'));
 });
 
 SingleHttpServer server(cfg, std::move(router));
@@ -619,7 +619,7 @@ Typical handler setup:
 HttpServerConfig serverCfg; serverCfg.withRequestDecompression(DecompressionConfig{});
 Router router;
 router.setDefault([](const HttpRequest& req){
-  return HttpResponse(200, "OK").body(std::string(req.body()));
+  return HttpResponse(200).body(std::string(req.body()));
 });
 SingleHttpServer server(std::move(serverCfg), std::move(router));
 ```
@@ -1370,7 +1370,7 @@ router.setPath(http::Method::GET, "/users/{id}/posts/{post}", [](const HttpReque
     std::string_view userId = it->second; // points into request buffer
     // copy if you need to keep it beyond request lifetime: std::string(userId)
   }
-  return HttpResponse(200, "OK");
+  return HttpResponse(200);
 });
 ```
 
@@ -1379,7 +1379,7 @@ router.setPath(http::Method::GET, "/users/{id}/posts/{post}", [](const HttpReque
 ```cpp
 Router router;
 router.setPath(http::Method::GET, "/files/{}/chunk/{}", [](const HttpRequest&) {
-  return HttpResponse(200, "OK");
+  return HttpResponse(200);
 });
 // In handler: req.pathParams().at("0"), req.pathParams().at("1")
 ```
@@ -1860,7 +1860,7 @@ Example:
 ```cpp
 Router router;
 router.setDefault([](const HttpRequest&, HttpResponseWriter& w){
-  w.status(200, "OK");
+  w.status(200);
   w.header("Content-Type", "text/plain");
   for (int i=0;i<5;++i) {
     if (!w.writeBody("chunk-" + std::to_string(i) + "\n")) break;
@@ -1987,13 +1987,13 @@ Example precedence illustration:
 Router router;
 router.setDefault([](const HttpRequest&){ return HttpResponse(200,"OK").body("GLOBAL"); });
 router.setDefault([](const HttpRequest&, HttpResponseWriter& w){ 
-  w.status(200,"OK");
+  w.status(200);
   w.contentType("text/plain");
   w.writeBody("STREAMFALLBACK"); 
   w.end(); 
 });
 router.setPath(http::Method::GET, "/stream", [](const HttpRequest&, HttpResponseWriter& w){ 
-  w.status(200,"OK"); 
+  w.status(200); 
   w.contentType("text/plain"); 
   w.writeBody("PS"); 
   w.end(); 

--- a/tests/http-additional_test.cpp
+++ b/tests/http-additional_test.cpp
@@ -760,7 +760,7 @@ TEST(SingleHttpServer, KeepAliveTimeoutNotTiedToPollInterval) {
   test::ClientConnection cnx(ts.port());
 
   // The server should proactively close the idle keep-alive connection quickly.
-  EXPECT_TRUE(test::WaitForPeerClose(cnx.fd(), 500ms));
+  EXPECT_TRUE(test::WaitForPeerClose(cnx.fd(), 500ms));  // NOLINT(misc-include-cleaner)
 
   ts.postConfigUpdate([oldPollInterval](HttpServerConfig& cfg) { cfg.withPollInterval(oldPollInterval); });
 }

--- a/tests/http-core_test.cpp
+++ b/tests/http-core_test.cpp
@@ -124,7 +124,8 @@ TEST(HttpHeadersCustom, ForwardsSingleAndMultipleCustomHeaders) {
 
 TEST(HttpHeadersCustom, LocationHeaderAllowed) {
   ts.router().setDefault([](const HttpRequest&) {
-    HttpResponse resp(302, "Found");
+    HttpResponse resp(302);
+    resp.reason("Found");
     resp.location("/new").body("");
     return resp;
   });
@@ -207,7 +208,7 @@ TEST(HttpHeaderTimeout, Emits408WhenHeadersCompletedAfterDeadline) {
   static constexpr std::chrono::milliseconds readTimeout = std::chrono::milliseconds{50};
   HeaderReadTimeoutScope headerTimeout(readTimeout);
 
-  ts.router().setDefault([](const HttpRequest&) { return HttpResponse(http::StatusCodeOK, "OK").body("hi"); });
+  ts.router().setDefault([](const HttpRequest&) { return HttpResponse("hi"); });
   std::this_thread::sleep_for(std::chrono::milliseconds(20));
   test::ClientConnection cnx(ts.port());
   int fd = cnx.fd();
@@ -229,7 +230,7 @@ TEST(HttpHeaderTimeout, Emits408WhenHeadersNeverComplete) {
   static constexpr std::chrono::milliseconds readTimeout = std::chrono::milliseconds{50};
   HeaderReadTimeoutScope headerTimeout(readTimeout);
 
-  ts.router().setDefault([](const HttpRequest&) { return HttpResponse(http::StatusCodeOK, "OK").body("hi"); });
+  ts.router().setDefault([](const HttpRequest&) { return HttpResponse("hi"); });
   test::ClientConnection cnx(ts.port());
   int fd = cnx.fd();
   ASSERT_GE(fd, 0) << "connect failed";

--- a/tests/http-stats_test.cpp
+++ b/tests/http-stats_test.cpp
@@ -16,10 +16,10 @@ TEST(HttpStats, BasicCountersIncrement) {
   HttpServerConfig cfg;
   cfg.withMaxRequestsPerConnection(5);
   test::TestServer ts(cfg);
-  ts.router().setDefault([]([[maybe_unused]] const HttpRequest& req) { return HttpResponse(200, "OK").body("hello"); });
+  ts.router().setDefault([]([[maybe_unused]] const HttpRequest& req) { return HttpResponse(200).body("hello"); });
   // Single request via throwing helper
   auto resp = test::requestOrThrow(ts.port());
-  ASSERT_TRUE(resp.contains("200 OK"));
+  ASSERT_TRUE(resp.starts_with("HTTP/1.1 200"));
   ts.stop();
   auto st = ts.server.stats();
   EXPECT_GT(st.totalBytesQueued, 0U);  // headers+body accounted

--- a/tests/http-tls-handshake_test.cpp
+++ b/tests/http-tls-handshake_test.cpp
@@ -87,7 +87,7 @@ TEST(HttpTlsAlpnNonStrict, MismatchAllowedAndNoMetricIncrement) {
       } else {
         capturedAlpn.clear();
       }
-      return HttpResponse(200, "OK").body("NS");
+      return HttpResponse("NS");
     });
     test::TlsClient::Options opts;
     opts.alpn = {"foo"};  // no overlap
@@ -644,7 +644,7 @@ TEST(HttpTlsMoveAlpn, MoveConstructBeforeRunMaintainsAlpnHandshake) {
 
   SingleHttpServer original(cfg);
   original.router().setDefault([](const HttpRequest& req) {
-    return HttpResponse(http::StatusCodeOK, "OK")
+    return HttpResponse(http::StatusCodeOK)
         .body(std::string("MOVEALPN:") + (req.alpnProtocol().empty() ? "-" : std::string(req.alpnProtocol())));
   });
 

--- a/tests/opentelemetry-e2e_test.cpp
+++ b/tests/opentelemetry-e2e_test.cpp
@@ -106,10 +106,10 @@ TEST(OpenTelemetryEndToEnd, EmitsTracesAndMetrics) {
 
   // Collect requests until we have both trace and metrics exports or timeout
   std::vector<test::CapturedOtlpRequest> captured;
-  const auto deadline = std::chrono::steady_clock::now() + 3s;
+  const auto deadline = std::chrono::steady_clock::now() + 3s;  // NOLINT(misc-include-cleaner)
   while (captured.size() < 2 && std::chrono::steady_clock::now() < deadline) {
     try {
-      captured.emplace_back(collector.waitForRequest(500ms));
+      captured.emplace_back(collector.waitForRequest(500ms));  // NOLINT(misc-include-cleaner)
     } catch (const std::exception&) {
       log::error("timed out waiting for a single request; loop and check overall deadline");
     }

--- a/tests/websocket-integration_test.cpp
+++ b/tests/websocket-integration_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -202,7 +203,7 @@ TEST_F(WebSocketTest, UpgradeSuccessful) {
   test::sendAll(conn.fd(), upgradeReq);
 
   // Read response
-  std::string response = test::recvWithTimeout(conn.fd(), 1000ms, 129UL);
+  std::string response = test::recvWithTimeout(conn.fd(), 1000ms, 129UL);  // NOLINT(misc-include-cleaner)
 
   // Verify 101 response
   EXPECT_TRUE(response.contains("HTTP/1.1 101")) << "Response: " << response;
@@ -229,7 +230,7 @@ TEST_F(WebSocketTest, UpgradeWithInvalidKey) {
   std::string upgradeReq = BuildUpgradeRequest("/ws", "shortkey");
   test::sendAll(conn.fd(), upgradeReq);
 
-  std::string response = test::recvWithTimeout(conn.fd(), 500ms);
+  std::string response = test::recvWithTimeout(conn.fd(), 500ms);  // NOLINT(misc-include-cleaner)
 
   // Should get 400 Bad Request
   EXPECT_TRUE(response.contains("HTTP/1.1 400")) << "Response: " << response;
@@ -295,7 +296,7 @@ TEST_F(WebSocketTest, SendAndReceiveTextMessage) {
   test::sendAll(conn.fd(), std::string_view(reinterpret_cast<const char*>(textFrame.data()), textFrame.size()));
 
   // Wait for echo response
-  std::this_thread::sleep_for(50ms);
+  std::this_thread::sleep_for(50ms);  // NOLINT(misc-include-cleaner)
 
   // Read response frame
   std::string response = test::recvWithTimeout(conn.fd(), 1000ms, 19UL);


### PR DESCRIPTION
The rationale is that `reason` usage is discouraged in modern HTTP/1.1, and even not supported in HTTP/2.