### PR TITLE
feat: DogStatsD client is now able to reconnect automatically

### DIFF
--- a/aeronet/http/include/aeronet/upgrade-handler.hpp
+++ b/aeronet/http/include/aeronet/upgrade-handler.hpp
@@ -119,7 +119,7 @@ namespace upgrade {
 ///
 /// @param validationResult  Result from ValidateHttp2Upgrade() (must be valid)
 /// @return                  Complete 101 response as raw bytes
-[[nodiscard]] RawChars BuildHttp2UpgradeResponse(const UpgradeValidationResult& validationResult);
+[[nodiscard]] std::string_view BuildHttp2UpgradeResponse(const UpgradeValidationResult& validationResult);
 #endif
 
 }  // namespace upgrade

--- a/aeronet/http/test/upgrade-handler_test.cpp
+++ b/aeronet/http/test/upgrade-handler_test.cpp
@@ -613,6 +613,7 @@ TEST(UpgradeHandlerTest, BuildWebSocketUpgradeResponse_WithProtocol) {
 
   EXPECT_TRUE(
       responseView.contains(MakeHttp1HeaderLine(websocket::SecWebSocketProtocol, validationResult.selectedProtocol)));
+  EXPECT_TRUE(responseView.ends_with(http::DoubleCRLF));
 }
 
 TEST(UpgradeHandlerTest, BuildWebSocketUpgradeResponse_WithDeflate) {
@@ -635,6 +636,7 @@ TEST(UpgradeHandlerTest, BuildWebSocketUpgradeResponse_WithDeflate) {
   EXPECT_TRUE(responseView.contains(expectedExtensions));
   // client_max_window_bits=15 is default, should not appear
   EXPECT_FALSE(responseView.contains("client_max_window_bits"));
+  EXPECT_TRUE(responseView.ends_with(http::DoubleCRLF));
 }
 #endif
 
@@ -832,6 +834,7 @@ TEST(UpgradeHandlerTest, BuildWebSocketUpgradeResponse_NoProtocolNoDeflate) {
   // Should not contain protocol or extensions headers
   EXPECT_FALSE(responseView.contains(websocket::SecWebSocketProtocol));
   EXPECT_FALSE(responseView.contains(websocket::SecWebSocketExtensions));
+  EXPECT_TRUE(responseView.ends_with(http::DoubleCRLF));
 }
 
 TEST(UpgradeHandlerTest, BuildWebSocketUpgradeResponse_WithDeflateNoContextTakeover) {
@@ -850,6 +853,7 @@ TEST(UpgradeHandlerTest, BuildWebSocketUpgradeResponse_WithDeflateNoContextTakeo
 
   EXPECT_TRUE(responseView.contains("server_no_context_takeover"));
   EXPECT_TRUE(responseView.contains("client_no_context_takeover"));
+  EXPECT_TRUE(responseView.ends_with(http::DoubleCRLF));
 }
 #endif
 

--- a/aeronet/main/include/aeronet/multi-http-server.hpp
+++ b/aeronet/main/include/aeronet/multi-http-server.hpp
@@ -235,14 +235,6 @@ class MultiHttpServer {
   // isDraining(): true if all underlying servers are currently draining.
   [[nodiscard]] bool isDraining() const;
 
-  // Access the telemetry context for custom tracing/spans.
-  // The returned reference is valid for the lifetime of the MultiHttpServer instance,
-  // but is invalidated if the server is moved.
-  // Precondition: empty() is false, otherwise undefined behavior.
-  [[nodiscard]] const tracing::TelemetryContext& telemetryContext() const noexcept {
-    return _servers[0].telemetryContext();
-  }
-
   // port(): The resolved listening port shared by all underlying servers.
   // If the port was ephemeral (0) at construction time, this returns the concrete port chosen by
   // the first server.

--- a/aeronet/main/include/aeronet/single-http-server.hpp
+++ b/aeronet/main/include/aeronet/single-http-server.hpp
@@ -363,11 +363,6 @@ class SingleHttpServer {
   // connections closed after current response), false otherwise.
   [[nodiscard]] bool isDraining() const { return _lifecycle.isDraining(); }
 
-  // Access the telemetry context for custom tracing/spans.
-  // The returned reference is valid for the lifetime of the SingleHttpServer instance,
-  // but is invalidated if the server is moved.
-  [[nodiscard]] const tracing::TelemetryContext& telemetryContext() const noexcept { return _telemetry; }
-
   // Retrieve current server statistics snapshot.
   [[nodiscard]] ServerStats stats() const;
 

--- a/aeronet/objects/include/aeronet/telemetry-config.hpp
+++ b/aeronet/objects/include/aeronet/telemetry-config.hpp
@@ -30,7 +30,7 @@ class TelemetryConfig {
   // Service name to attach to traces. If empty, the application may supply a default.
   [[nodiscard]] std::string_view serviceName() const { return _staticStrings[1]; }
 
-  // DogStatsD socket path (e.g. /var/run/datadog/dsd.socket). Empty => consult environment.
+  // DogStatsD socket path (e.g. /var/run/datadog/dsd.socket). Empty => disabled.
   [[nodiscard]] std::string_view dogstatsdSocketPath() const { return _staticStrings[2]; }
 
   // Optional namespace prefix for DogStatsD metrics (defaults to serviceName when empty).

--- a/aeronet/objects/include/aeronet/tracing/tracer.hpp
+++ b/aeronet/objects/include/aeronet/tracing/tracer.hpp
@@ -56,7 +56,8 @@ class TelemetryContext {
  public:
   TelemetryContext() noexcept;
 
-  explicit TelemetryContext(const aeronet::TelemetryConfig &cfg);
+  // Constructs a new telemetry context from configuration.
+  explicit TelemetryContext(const TelemetryConfig &cfg);
 
   // Non-copyable, movable
   TelemetryContext(const TelemetryContext &) = delete;
@@ -83,7 +84,7 @@ class TelemetryContext {
 
   // Access underlying DogStatsD client, or nullptr if not enabled.
   // You can use it to emit custom DogStatsD metrics.
-  [[nodiscard]] const DogStatsD *dogstatsdClient() const noexcept;
+  [[nodiscard]] DogStatsD *dogstatsdClient() const noexcept;
 
  private:
   std::unique_ptr<TelemetryContextImpl> _impl;

--- a/aeronet/objects/src/dogstatsd-metrics.hpp
+++ b/aeronet/objects/src/dogstatsd-metrics.hpp
@@ -22,31 +22,31 @@ class DogStatsdMetrics {
     }
   }
 
-  void increment(std::string_view metric, uint64_t delta = 1UL) const noexcept {
+  void increment(std::string_view metric, uint64_t delta = 1UL) noexcept {
     if (_pTags != nullptr) {
       _client.increment(metric, delta, *_pTags);
     }
   }
 
-  void gauge(std::string_view metric, int64_t value) const noexcept {
+  void gauge(std::string_view metric, int64_t value) noexcept {
     if (_pTags != nullptr) {
       _client.gauge(metric, value, *_pTags);
     }
   }
 
-  void histogram(std::string_view metric, double value) const noexcept {
+  void histogram(std::string_view metric, double value) noexcept {
     if (_pTags != nullptr) {
       _client.histogram(metric, value, *_pTags);
     }
   }
 
-  void timing(std::string_view metric, std::chrono::milliseconds ms) const noexcept {
+  void timing(std::string_view metric, std::chrono::milliseconds ms) noexcept {
     if (_pTags != nullptr) {
       _client.timing(metric, ms, *_pTags);
     }
   }
 
-  [[nodiscard]] const DogStatsD& dogstatsdClient() const noexcept { return _client; }
+  [[nodiscard]] DogStatsD& dogstatsdClient() noexcept { return _client; }
 
  private:
   DogStatsD _client;

--- a/aeronet/objects/src/otel-tracer.cpp
+++ b/aeronet/objects/src/otel-tracer.cpp
@@ -367,7 +367,7 @@ void TelemetryContext::timing(std::string_view name, std::chrono::milliseconds m
   }
 }
 
-const DogStatsD* TelemetryContext::dogstatsdClient() const noexcept {
+DogStatsD* TelemetryContext::dogstatsdClient() const noexcept {
   return _impl ? &_impl->_dogstatsd.dogstatsdClient() : nullptr;
 }
 

--- a/aeronet/objects/src/void-tracer.cpp
+++ b/aeronet/objects/src/void-tracer.cpp
@@ -60,7 +60,7 @@ void TelemetryContext::timing(std::string_view name, std::chrono::milliseconds m
   }
 }
 
-const DogStatsD* TelemetryContext::dogstatsdClient() const noexcept {
+DogStatsD* TelemetryContext::dogstatsdClient() const noexcept {
   if (_impl) {
     return &_impl->dogstatsd.dogstatsdClient();
   }

--- a/aeronet/objects/test/dogstatsd_test.cpp
+++ b/aeronet/objects/test/dogstatsd_test.cpp
@@ -16,6 +16,15 @@
 
 namespace aeronet {
 
+TEST(DogStatsDTest, DefaultConstructorDisabled) {
+  DogStatsD client;
+  EXPECT_NO_THROW(client.increment("noop"));
+  EXPECT_NO_THROW(client.gauge("noop", 1.0));
+  EXPECT_NO_THROW(client.histogram("noop", 2.0));
+  EXPECT_NO_THROW(client.timing("noop", std::chrono::milliseconds{1}));
+  EXPECT_NO_THROW(client.set("noop", "value"));
+}
+
 TEST(DogStatsDTest, EmptyNamespace) {
   test::UnixDogstatsdSink sink;
   DogStatsD client(sink.path(), "");
@@ -30,18 +39,59 @@ TEST(DogStatsDTest, SocketFails) {
 }
 
 TEST(DogStatsDTest, SocketTimeout) {
-  // Use an invalid socket path to trigger syscall failure
-  EXPECT_THROW(DogStatsD("/invalid/path/to/socket.sock", "svc", std::chrono::milliseconds{5}), std::runtime_error);
+  // Simulate missing socket file: constructor should not throw, it should
+  // defer retry (ENOENT is a connectivity/runtime condition).
+  test::PushConnectAction({-1, ENOENT});
+  EXPECT_NO_THROW(DogStatsD("/invalid/path/to/socket.sock", "svc"));
+}
+
+TEST(DogStatsDTest, SocketInvalidFormatThrows) {
+  // Simulate a structural/path format error (ENOTDIR) that should be
+  // considered a configuration error and cause the constructor to throw.
+  test::PushConnectAction({-1, ENOTDIR});
+  EXPECT_THROW(DogStatsD("/invalid/path/to/socket.sock", "svc"), std::invalid_argument);
+}
+
+TEST(DogStatsDTest, SocketInvalid_EISDIR) {
+  test::PushConnectAction({-1, EISDIR});
+  EXPECT_THROW(DogStatsD("/invalid/path/to/socket.sock", "svc"), std::invalid_argument);
+}
+
+TEST(DogStatsDTest, SocketInvalid_ELOOP) {
+  test::PushConnectAction({-1, ELOOP});
+  EXPECT_THROW(DogStatsD("/invalid/path/to/socket.sock", "svc"), std::invalid_argument);
+}
+
+TEST(DogStatsDTest, SocketInvalid_EINVAL) {
+  test::PushConnectAction({-1, EINVAL});
+  EXPECT_THROW(DogStatsD("/invalid/path/to/socket.sock", "svc"), std::invalid_argument);
+}
+
+TEST(DogStatsDTest, SocketInvalid_ENOTSOCK) {
+  test::PushConnectAction({-1, ENOTSOCK});
+  EXPECT_THROW(DogStatsD("/invalid/path/to/socket.sock", "svc"), std::invalid_argument);
+}
+
+TEST(DogStatsDTest, SocketInvalid_EACCES) {
+  test::PushConnectAction({-1, EACCES});
+  EXPECT_THROW(DogStatsD("/invalid/path/to/socket.sock", "svc"), std::invalid_argument);
+}
+
+TEST(DogStatsDTest, SocketInvalid_EPERM) {
+  test::PushConnectAction({-1, EPERM});
+  EXPECT_THROW(DogStatsD("/invalid/path/to/socket.sock", "svc"), std::invalid_argument);
 }
 
 TEST(DogStatsDTest, SendMetricFailsToAllocateMemory) {
   test::UnixDogstatsdSink sink;
   DogStatsD client(sink.path(), "svc");
 
-  test::FailNextMalloc(1);  // cause next malloc to fail
+  test::FailNextRealloc(1);  // cause next realloc to fail
 
   // Should not throw despite allocation failure
-  EXPECT_NO_THROW(client.increment("requests"));
+  EXPECT_NO_THROW(
+      client.increment("a-very-long-metric-name-to-trigger-allocation-because-it-will-allocate-already-a-buffer-of-"
+                       "some-dozens-of-additional-chars-at-constructor-time"));
 }
 
 TEST(DogStatsDTest, SendSystemError) {
@@ -79,7 +129,7 @@ TEST(DogStatsDTest, SendsAllMetricTypesWithTags) {
 }
 
 TEST(DogStatsDTest, RespectsExistingNamespaceDotAndEmptyTags) {
-  aeronet::test::UnixDogstatsdSink sink;
+  test::UnixDogstatsdSink sink;
   DogStatsD client(sink.path(), "svc.");
 
   client.increment("requests");
@@ -101,15 +151,94 @@ TEST(DogStatsDTest, RejectsTooLongSocketPath) {
 }
 
 TEST(DogStatsDTest, RejectsTooLongNamespace) {
+  test::UnixDogstatsdSink sink;
   std::string ns(256, 'n');
-  EXPECT_THROW(DogStatsD({}, ns), std::invalid_argument);
+  EXPECT_THROW(DogStatsD(sink.path(), ns), std::invalid_argument);
 }
 
 TEST(DogStatsDTest, SendFailureLogsAndContinues) {
-  aeronet::test::UnixDogstatsdSink sink;
+  test::UnixDogstatsdSink sink;
   DogStatsD client(sink.path(), "svc");
   sink.closeAndUnlink();
   EXPECT_NO_THROW(client.increment("lost", 1));
+}
+
+TEST(DogStatsDTest, SendEagainIsDropped) {
+  test::UnixDogstatsdSink sink;
+  DogStatsD client(sink.path(), "svc");
+
+  // Inject EAGAIN for the next send; the client should treat it as a dropped metric
+  // and not mark the connection for immediate reconnect. No exception should be thrown.
+  test::PushSendAction({-1, EAGAIN});
+  EXPECT_NO_THROW(client.increment("lost", 1));
+
+  // Subsequent sends should still work (no socket teardown on EAGAIN)
+  client.increment("ok", 1);
+  EXPECT_EQ(sink.recvMessage(), "svc.ok:1|c");
+}
+
+TEST(DogStatsDTest, IfFirstConnectFailsReconnectShouldBeAttemptedOnNextSend) {
+  // Create a sink but arrange for the first connect() to fail. The DogStatsD
+  // constructor calls tryReconnect(), which will pop the first connect action.
+  // We then send many messages; after enough sends the client will attempt
+  // reconnects periodically (controlled by kReconnectionThreshold). We push
+  // a successful connect action after some failures and expect at least one
+  // message to be received by the sink.
+
+  test::UnixDogstatsdSink sink;
+
+  // First connect attempt (from constructor) fails with ENOENT.
+  test::PushConnectAction({-1, ENOENT});
+
+  // Create client: initial connect will fail but object should be constructed.
+  DogStatsD client(sink.path(), "svc");
+
+  // Now arrange for subsequent connect attempts to succeed once we want them to.
+  // We'll not push a success yet — the real connect will attempt to connect to
+  // the sink's path (which is valid) when the action queue is empty. To ensure
+  // reconnect eventually succeeds, push a success action after some messages.
+
+  // Send many messages to trigger reconnect attempts. We don't want this test to
+  // take too long, so pick a number greater than kReconnectionThreshold (80).
+  client.increment("requests");
+
+  // At least one of the sends after connect success should be received by the sink.
+  // Allow small timeout for delivery.
+  const std::string msg = sink.recvMessage(500);
+  EXPECT_TRUE(!msg.empty());
+}
+
+TEST(DogStatsDTest, RetryShouldBePeriodic) {
+  test::UnixDogstatsdSink sink;
+
+  // First connect attempt (from constructor) fails with ENOENT.
+  test::PushConnectAction({-1, ENOENT});
+
+  // Create client: initial connect will fail but object should be constructed.
+  DogStatsD client(sink.path(), "svc");
+
+  // Also make immediate next connect attempt fail.
+  test::PushConnectAction({-1, ENOENT});
+
+  // Now arrange for subsequent connect attempts to succeed once we want them to.
+  // We'll not push a success yet — the real connect will attempt to connect to
+  // the sink's path (which is valid) when the action queue is empty. To ensure
+  // reconnect eventually succeeds, push a success action after some messages.
+  for (int messagePos = 0; messagePos < 49; ++messagePos) {
+    client.increment("requests");
+  }
+
+  // None of the sends should be received by the sink yet.
+  std::string msg = sink.recvMessage(100);
+  EXPECT_TRUE(msg.empty());
+
+  // next one should trigger a reconnect attempt that will succeed.
+  client.increment("requests");
+
+  // At least one of the sends after connect success should be received by the sink.
+  // Allow small timeout for delivery.
+  msg = sink.recvMessage(500);
+  EXPECT_FALSE(msg.empty());
 }
 
 }  // namespace aeronet

--- a/aeronet/test_support/basic/src/unix-dogstatsd-sink.cpp
+++ b/aeronet/test_support/basic/src/unix-dogstatsd-sink.cpp
@@ -67,7 +67,7 @@ std::string UnixDogstatsdSink::recvMessage(int timeoutMs) const {
   if (ready <= 0 || (pfd.revents & POLLIN) == 0) {
     return {};
   }
-  std::array<char, 512> buf{};
+  std::array<char, 512> buf;
   const ssize_t bytes = ::recv(_fd.fd(), buf.data(), buf.size(), 0);
   if (bytes <= 0) {
     return {};

--- a/aeronet/websocket/include/aeronet/websocket-deflate.hpp
+++ b/aeronet/websocket/include/aeronet/websocket-deflate.hpp
@@ -9,6 +9,7 @@
 #include <type_traits>
 
 #include "aeronet/raw-bytes.hpp"
+#include "aeronet/raw-chars.hpp"
 
 namespace aeronet::websocket {
 
@@ -64,10 +65,13 @@ struct DeflateNegotiatedParams {
 [[nodiscard]] std::optional<DeflateNegotiatedParams> ParseDeflateOffer(std::string_view extensionOffer,
                                                                        const DeflateConfig& serverConfig);
 
+/// Compute the size of the Sec-WebSocket-Extensions response header value for permessage-deflate.
+std::size_t ComputeDeflateResponseSize(DeflateNegotiatedParams params);
+
 /// Build the Sec-WebSocket-Extensions response header value for permessage-deflate.
 /// @param params The negotiated parameters
-/// @return Extension response string
-[[nodiscard]] RawBytes BuildDeflateResponse(DeflateNegotiatedParams params);
+/// @param output Output buffer to append the response string to
+void BuildDeflateResponse(DeflateNegotiatedParams params, RawChars& output);
 
 /// RAII wrapper for zlib deflate/inflate context.
 /// This is an internal implementation detail.

--- a/aeronet/websocket/test/websocket-deflate_test.cpp
+++ b/aeronet/websocket/test/websocket-deflate_test.cpp
@@ -267,7 +267,8 @@ TEST(WebSocketDeflateTest, ParseDeflateOffer_CaseInsensitiveParams) {
 
 TEST(WebSocketDeflateTest, BuildDeflateResponse_Defaults) {
   DeflateNegotiatedParams params;
-  auto response = BuildDeflateResponse(params);
+  RawChars response;
+  BuildDeflateResponse(params, response);
 
   // With all defaults, should just be the extension name
   EXPECT_EQ(std::string_view(reinterpret_cast<const char *>(response.data()), response.size()), "permessage-deflate");
@@ -276,7 +277,8 @@ TEST(WebSocketDeflateTest, BuildDeflateResponse_Defaults) {
 TEST(WebSocketDeflateTest, BuildDeflateResponse_ServerNoContextTakeover) {
   DeflateNegotiatedParams params;
   params.serverNoContextTakeover = true;
-  auto response = BuildDeflateResponse(params);
+  RawChars response;
+  BuildDeflateResponse(params, response);
 
   EXPECT_TRUE(std::string_view(reinterpret_cast<const char *>(response.data()), response.size())
                   .starts_with("permessage-deflate"));
@@ -287,7 +289,8 @@ TEST(WebSocketDeflateTest, BuildDeflateResponse_ServerNoContextTakeover) {
 TEST(WebSocketDeflateTest, BuildDeflateResponse_ClientNoContextTakeover) {
   DeflateNegotiatedParams params;
   params.clientNoContextTakeover = true;
-  auto response = BuildDeflateResponse(params);
+  RawChars response;
+  BuildDeflateResponse(params, response);
 
   EXPECT_TRUE(std::string_view(reinterpret_cast<const char *>(response.data()), response.size())
                   .contains("client_no_context_takeover"));
@@ -297,7 +300,8 @@ TEST(WebSocketDeflateTest, BuildDeflateResponse_ReducedWindowBits) {
   DeflateNegotiatedParams params;
   params.serverMaxWindowBits = 10;
   params.clientMaxWindowBits = 12;
-  auto response = BuildDeflateResponse(params);
+  RawChars response;
+  BuildDeflateResponse(params, response);
 
   EXPECT_TRUE(std::string_view(reinterpret_cast<const char *>(response.data()), response.size())
                   .contains("server_max_window_bits=10"));
@@ -311,7 +315,8 @@ TEST(WebSocketDeflateTest, BuildDeflateResponse_AllParams) {
   params.clientNoContextTakeover = true;
   params.serverMaxWindowBits = 9;
   params.clientMaxWindowBits = 10;
-  auto response = BuildDeflateResponse(params);
+  RawChars response;
+  BuildDeflateResponse(params, response);
 
   EXPECT_TRUE(std::string_view(reinterpret_cast<const char *>(response.data()), response.size())
                   .contains("server_no_context_takeover"));
@@ -327,7 +332,8 @@ TEST(WebSocketDeflateTest, BuildDeflateResponse_DefaultWindowBitsNotIncluded) {
   DeflateNegotiatedParams params;
   params.serverMaxWindowBits = 15;  // Default
   params.clientMaxWindowBits = 15;  // Default
-  auto response = BuildDeflateResponse(params);
+  RawChars response;
+  BuildDeflateResponse(params, response);
 
   // Default window bits should not be included
   EXPECT_TRUE(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,10 +14,13 @@ All notable changes to aeronet are documented in this file.
 - New size / length method helpers in `HttpResponse`, with `reserve` and capacity getters.
 - All Header values stored in `HttpResponse` and `HttpResponseWriter` are now trimmed of leading/trailing whitespace on set.
 - New option `HttpServerConfig::addTrailerHeader` to automatically emit `trailer` header when trailers are added to responses in `HTTP/1.1` only.
+- `DogStatsD` is now able to reconnect automatically if the UDS socket becomes unavailable. The client is also more efficient.
 
 ### Breaking Changes
 
 - Minor validation enforcement: `HttpServerConfig::globalHeaders` now MUST be key value separated by `http::HeaderSep`.
+- Removed `telemetryContext()` methods from `HttpServer` and `SingleHttpServer`. You can construct a custom `TelemetryContext` instead if needed.
+- Telemetry metric methods (including `DogStatsD` ones) are no more `const` qualified
 
 ## [1.0.0] - 2026-01-17
 

--- a/tests/http-core_test.cpp
+++ b/tests/http-core_test.cpp
@@ -27,6 +27,7 @@
 #include "aeronet/telemetry-config.hpp"
 #include "aeronet/test_server_fixture.hpp"
 #include "aeronet/test_util.hpp"
+#include "aeronet/tracing/tracer.hpp"
 #include "aeronet/unix-dogstatsd-sink.hpp"
 
 using namespace std::chrono_literals;
@@ -556,7 +557,8 @@ TEST(HttpServerTelemetry, DogStatsDClientSendsMetricsWithServiceName) {
 
   SingleHttpServer server(cfg);
 
-  auto& telemetryContext = server.telemetryContext();
+  tracing::TelemetryContext telemetryContext(cfg.telemetry);
+
   auto* pDogStatsDClient = telemetryContext.dogstatsdClient();
   ASSERT_NE(pDogStatsDClient, nullptr);
 
@@ -585,7 +587,7 @@ TEST(HttpServerTelemetry, DogStatsDClientSendsMetricsWithoutServiceName) {
 
   SingleHttpServer server(cfg);
 
-  auto& telemetryContext = server.telemetryContext();
+  tracing::TelemetryContext telemetryContext(cfg.telemetry);
   auto* pDogStatsDClient = telemetryContext.dogstatsdClient();
   ASSERT_NE(pDogStatsDClient, nullptr);
 


### PR DESCRIPTION
- Removed `telemetryContext()` methods from HttpServers, it was not very useful and it was not safe for concurrent interaction (now forbidden with DogStatsD client which has a mutable internal state). Clients can just create their custom telemetry config, the constructor is public.