### PR TITLE
enforce valid header names in HttpResponse / Writer

### DIFF
--- a/aeronet/main/src/http-response-writer.cpp
+++ b/aeronet/main/src/http-response-writer.cpp
@@ -18,6 +18,7 @@
 #include "aeronet/file.hpp"
 #include "aeronet/header-write.hpp"
 #include "aeronet/http-constants.hpp"
+#include "aeronet/http-header.hpp"
 #include "aeronet/http-method.hpp"
 #include "aeronet/http-request-dispatch.hpp"
 #include "aeronet/http-response-data.hpp"
@@ -75,6 +76,9 @@ void HttpResponseWriter::reason(std::string_view reason) {
 }
 
 void HttpResponseWriter::headerAddLine(std::string_view name, std::string_view value) {
+  if (!http::IsValidHeaderName(name)) [[unlikely]] {
+    throw std::invalid_argument("Invalid HTTP header name");
+  }
   if (_state != State::Opened) {
     log::warn("Streaming: cannot add header after headers sent");
     return;
@@ -87,6 +91,9 @@ void HttpResponseWriter::headerAddLine(std::string_view name, std::string_view v
 }
 
 void HttpResponseWriter::header(std::string_view name, std::string_view value) {
+  if (!http::IsValidHeaderName(name)) [[unlikely]] {
+    throw std::invalid_argument("Invalid HTTP header name");
+  }
   if (_state != State::Opened) {
     log::warn("Streaming: cannot add header after headers sent");
     return;
@@ -251,6 +258,9 @@ bool HttpResponseWriter::writeBody(std::string_view data) {
 }
 
 void HttpResponseWriter::trailerAddLine(std::string_view name, std::string_view value) {
+  if (!http::IsValidHeaderName(name)) [[unlikely]] {
+    throw std::invalid_argument("Invalid HTTP header name");
+  }
   if (_state == State::Ended || _state == State::Failed) {
     log::warn("Streaming: trailerAddLine ignored fd # {} name={} reason={}", _fd, name,
               _state == State::Failed ? "writer-failed" : "already-ended");

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to aeronet are documented in this file.
 - Minor validation enforcement: `HttpServerConfig::globalHeaders` now MUST be key value separated by `http::HeaderSep`.
 - Removed `telemetryContext()` methods from `HttpServer` and `SingleHttpServer`. You can construct a custom `TelemetryContext` instead if needed.
 - Telemetry metric methods (including `DogStatsD` ones) are no more `const` qualified
+- Now check at runtime if header name about to be inserted in a response is valid, otherwise throws `std::invalid_argument`
 
 ### Improvements
 

--- a/tests/http-streaming_test.cpp
+++ b/tests/http-streaming_test.cpp
@@ -122,6 +122,8 @@ TEST(HttpStreaming, ChunkedSimple) {
   ts.router().setDefault([]([[maybe_unused]] const HttpRequest& req, HttpResponseWriter& writer) {
     writer.status(200);
     writer.contentType("text/plain");
+    EXPECT_THROW(writer.header("Invalid Header", "value"), std::invalid_argument);
+    EXPECT_THROW(writer.headerAddLine("Invalid Header", "value"), std::invalid_argument);
     writer.headerAddLine("X-Custom", "value");
     writer.writeBody("hello ");
     writer.status(400);                             // should be ignored after headers sent
@@ -1117,6 +1119,7 @@ TEST(HttpResponseWriterFailures, EmitLastChunkFailure) {
     writer.status(http::StatusCodeOK);
     writer.writeBody("chunk1");
     writer.trailerAddLine("X-Trailer", "value");
+    EXPECT_THROW(writer.trailerAddLine("Invalid:header", "value"), std::invalid_argument);
     // end() calls emitLastChunk
     writer.end();
   });


### PR DESCRIPTION
Also re-organize HttpResponse tests.