### PR TITLE
chore: decrease default number of cached connections from 100 to 10

### DIFF
--- a/aeronet/objects/include/aeronet/http-server-config.hpp
+++ b/aeronet/objects/include/aeronet/http-server-config.hpp
@@ -99,8 +99,8 @@ struct HttpServerConfig {
   uint32_t maxRequestsPerConnection{100000};
 
   // Maximum number of closed ConnectionState objects to cache for reuse to reduce allocations.
-  // When the limit is reached, closed connections are fully destroyed. Default: 100.
-  uint32_t maxCachedConnections{100};
+  // When the limit is reached, closed connections are fully destroyed. Default: 10.
+  uint32_t maxCachedConnections{10};
 
   // Idle timeout for keep-alive connections (duration to wait for next request after previous response is fully
   // sent). Once exceeded the server proactively closes the connection.


### PR DESCRIPTION
Because they can take a huge amount of memory, and having a lot available is not very useful.