### PR TITLE
fix: reset request trailers length to 0 for keep-alive requests on th…

### DIFF
--- a/aeronet/server/src/http-parser.cpp
+++ b/aeronet/server/src/http-parser.cpp
@@ -42,6 +42,10 @@ SingleHttpServer::BodyDecodeStatus SingleHttpServer::decodeFixedLengthBody(Conne
                                                                            std::size_t& consumedBytes) {
   ConnectionState& state = _connections.connectionState(cnxIt);
   HttpRequestView& request = state.request;
+  // Fixed-length (non-chunked) requests never carry trailers (RFC 7230 section 4.1.2). Clear any trailerLen
+  // left over from a previous chunked request on this (keep-alive) connection so the request-finalization
+  // path does not spuriously re-parse stale trailer bytes into this request's trailers.
+  state.trailerLen = 0;
   auto optContentLength = request.headerValue(http::ContentLength);
   const std::size_t headerEnd = request.headSpanSize();
   if (!optContentLength) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to aeronet are documented in this file.
 
 ### Bug fixes
 
+- **Request trailers could leak across keep-alive requests**: after a chunked request carrying trailers, the per-connection trailer length was not reset for a subsequent fixed-length request on the same connection, so the server spuriously re-parsed the previous request's trailer bytes into `HttpRequestView::trailers()`. The trailer length is now cleared for non-chunked bodies.
 - **HTTP/2 responses larger than the peer's flow-control window could never be delivered** — a buffered response body exceeding the stream/connection send window (e.g. > ~64 KiB against the RFC 9113 default window) failed with `FLOW_CONTROL_ERROR` and hung; the window-exhausted remainder is now deferred and flushed as `WINDOW_UPDATE`s arrive, trailers included.
 - **HTTP/2 server leaked active-stream accounting** for responses completed outside frame processing (flow-control-deferred bodies, file payloads flushed from `onOutputWritten`, async completions), so a long-lived connection eventually died with `Max concurrent streams exceeded`.
 - **HTTP/2 responses could carry field values with trailing whitespace**, which strict peers (nghttp2, hence curl) reject per RFC 9113 §8.2.1 — so every compressed response over HTTP/2 failed for such clients. Header values are now OWS-trimmed before HPACK encoding.

--- a/tests/http-trailers_test.cpp
+++ b/tests/http-trailers_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -113,6 +114,48 @@ TEST(HttpTrailers, MultipleTrailers) {
   test::sendAll(fd, req);
   std::string resp = test::recvUntilClosed(fd);
   ASSERT_TRUE(resp.starts_with("HTTP/1.1 200"));
+}
+
+// Regression: a chunked request carrying trailers followed by a fixed-length request on the SAME keep-alive
+// connection must not leak the first request's trailers into the second. The per-connection trailerLen is
+// reset for non-chunked bodies (see SingleHttpServer::decodeFixedLengthBody); without that reset the second
+// request would spuriously re-parse the previous request's trailer bytes.
+TEST(HttpTrailers, TrailersDoNotLeakAcrossKeepAliveRequests) {
+  ts.router().setDefault(
+      [](const HttpRequestView& req) { return HttpResponse("trailers=" + std::to_string(req.trailers().size())); });
+
+  test::ClientConnection sock(port);
+  NativeHandle fd = sock.fd();
+
+  using namespace std::chrono_literals;
+
+  // First request: chunked body + one trailer; keep the connection open (no Connection: close).
+  const std::string chunkedWithTrailer =
+      "POST /first HTTP/1.1\r\n"
+      "Host: example.com\r\n"
+      "Transfer-Encoding: chunked\r\n"
+      "\r\n"
+      "4\r\ndata\r\n"
+      "0\r\n"
+      "X-Checksum: abc123\r\n"
+      "\r\n";
+  test::sendAll(fd, chunkedWithTrailer);
+  const std::string first = test::recvWithTimeout(fd, 500ms);  // NOLINT(misc-include-cleaner)
+  ASSERT_TRUE(first.starts_with("HTTP/1.1 200")) << first;
+  EXPECT_TRUE(first.contains("trailers=1")) << first;
+
+  // Second request on the same connection: fixed-length, no trailers.
+  const std::string fixedLength =
+      "POST /second HTTP/1.1\r\n"
+      "Host: example.com\r\n"
+      "Content-Length: 5\r\n"
+      "Connection: close\r\n"
+      "\r\n"
+      "hello";
+  test::sendAll(fd, fixedLength);
+  const std::string second = test::recvUntilClosed(fd);
+  ASSERT_TRUE(second.starts_with("HTTP/1.1 200")) << second;
+  EXPECT_TRUE(second.contains("trailers=0")) << second;  // must NOT inherit the first request's trailer
 }
 
 // Empty trailers (just zero chunk and terminating CRLF)


### PR DESCRIPTION
…e same connection