### PR TITLE
perf: improve date header write

### DIFF
--- a/aeronet/http/src/http-response.cpp
+++ b/aeronet/http/src/http-response.cpp
@@ -119,7 +119,7 @@ HttpResponse& HttpResponse::status(http::StatusCode statusCode) & {
   if (statusCode < 100 || statusCode > 999) [[unlikely]] {
     throw std::invalid_argument("Invalid HTTP status code, should be 3 digits");
   }
-  write3(_data.data() + kStatusCodeBeg, statusCode);
+  writeStatusCode(_data.data() + kStatusCodeBeg, statusCode);
   return *this;
 }
 

--- a/aeronet/http2/src/http2-connection.cpp
+++ b/aeronet/http2/src/http2-connection.cpp
@@ -910,7 +910,7 @@ void Http2Connection::encodeHeaders(uint32_t streamId, http::StatusCode statusCo
   // Encode :status pseudo-header first if present
   if (statusCode >= 100) {
     char statusBuf[3];
-    const std::string_view statusStr(statusBuf, write3(statusBuf, statusCode));
+    const std::string_view statusStr(statusBuf, writeStatusCode(statusBuf, statusCode));
     _hpackEncoder.encode(_outputBuffer, http::PseudoHeaderStatus, statusStr);
   }
 

--- a/aeronet/server/src/access-log-writer.cpp
+++ b/aeronet/server/src/access-log-writer.cpp
@@ -137,7 +137,7 @@ void AccessLogWriter::formatCLF(const RequestMetrics& metrics) {
   // "\" <status> <bytesOut>"
   *out++ = '"';
   *out++ = ' ';
-  out = write3(out, metrics.status);
+  out = writeStatusCode(out, metrics.status);
   *out++ = ' ';
   out = AppendIntegral(out, metrics.bytesOut);
 
@@ -188,7 +188,7 @@ void AccessLogWriter::formatJSON(const RequestMetrics& metrics) {
   out = Append(kPathPart, out);
   out = Append(metrics.path, out);
   out = Append(kStatusPart, out);
-  out = write3(out, metrics.status);
+  out = writeStatusCode(out, metrics.status);
   out = Append(kBytesOutPart, out);
   out = AppendIntegral(out, metrics.bytesOut);
   out = Append(kDurationPart, out);

--- a/aeronet/server/src/single-http-server.cpp
+++ b/aeronet/server/src/single-http-server.cpp
@@ -1495,7 +1495,7 @@ bool SingleHttpServer::handleExpectHeader(ConnectionIt cnxIt, std::string_view e
               buf.setSize(buf.capacity());
 
               char* insertPtr = Append(kHttpResponseLinePrefix, buf.data());
-              insertPtr = write3(insertPtr, status);
+              insertPtr = writeStatusCode(insertPtr, status);
               Copy(http::DoubleCRLF, insertPtr);
 
               queueData(cnxIt, HttpMessageData(std::move(buf)));

--- a/aeronet/tech/include/aeronet/simple-charconv.hpp
+++ b/aeronet/tech/include/aeronet/simple-charconv.hpp
@@ -3,27 +3,52 @@
 #include <concepts>
 #include <cstdint>
 
+#include "aeronet/http-status-code.hpp"
+
 namespace aeronet {
 
-constexpr auto write2(auto buf, std::integral auto value) {
-  *buf = static_cast<char>('0' + (value / 10));
-  *++buf = static_cast<char>('0' + (value % 10));
-  return ++buf;
+constexpr auto write2(auto buf, std::integral auto value) noexcept {
+  static constexpr char kDigitPairs[][2] = {
+      {'0', '0'}, {'0', '1'}, {'0', '2'}, {'0', '3'}, {'0', '4'}, {'0', '5'}, {'0', '6'}, {'0', '7'}, {'0', '8'},
+      {'0', '9'}, {'1', '0'}, {'1', '1'}, {'1', '2'}, {'1', '3'}, {'1', '4'}, {'1', '5'}, {'1', '6'}, {'1', '7'},
+      {'1', '8'}, {'1', '9'}, {'2', '0'}, {'2', '1'}, {'2', '2'}, {'2', '3'}, {'2', '4'}, {'2', '5'}, {'2', '6'},
+      {'2', '7'}, {'2', '8'}, {'2', '9'}, {'3', '0'}, {'3', '1'}, {'3', '2'}, {'3', '3'}, {'3', '4'}, {'3', '5'},
+      {'3', '6'}, {'3', '7'}, {'3', '8'}, {'3', '9'}, {'4', '0'}, {'4', '1'}, {'4', '2'}, {'4', '3'}, {'4', '4'},
+      {'4', '5'}, {'4', '6'}, {'4', '7'}, {'4', '8'}, {'4', '9'}, {'5', '0'}, {'5', '1'}, {'5', '2'}, {'5', '3'},
+      {'5', '4'}, {'5', '5'}, {'5', '6'}, {'5', '7'}, {'5', '8'}, {'5', '9'}, {'6', '0'}, {'6', '1'}, {'6', '2'},
+      {'6', '3'}, {'6', '4'}, {'6', '5'}, {'6', '6'}, {'6', '7'}, {'6', '8'}, {'6', '9'}, {'7', '0'}, {'7', '1'},
+      {'7', '2'}, {'7', '3'}, {'7', '4'}, {'7', '5'}, {'7', '6'}, {'7', '7'}, {'7', '8'}, {'7', '9'}, {'8', '0'},
+      {'8', '1'}, {'8', '2'}, {'8', '3'}, {'8', '4'}, {'8', '5'}, {'8', '6'}, {'8', '7'}, {'8', '8'}, {'8', '9'},
+      {'9', '0'}, {'9', '1'}, {'9', '2'}, {'9', '3'}, {'9', '4'}, {'9', '5'}, {'9', '6'}, {'9', '7'}, {'9', '8'},
+      {'9', '9'},
+  };
+
+  const char* pCouple = kDigitPairs[static_cast<uint8_t>(value)];
+  buf[0] = pCouple[0];
+  buf[1] = pCouple[1];
+  return buf + 2;
 }
 
-constexpr auto write3(auto buf, std::integral auto value) {
-  *buf = static_cast<char>('0' + (value / 100));
-  *++buf = static_cast<char>('0' + ((value / 10) % 10));
-  *++buf = static_cast<char>('0' + (value % 10));
-  return ++buf;
+constexpr auto write4(auto buf, std::integral auto value) noexcept {
+  // Single div/mod by a compile-time constant (100), reusing write2's
+  // table for both halves instead of extracting four digits separately.
+  write2(buf, static_cast<unsigned>(value / 100));
+  return write2(buf + 2, static_cast<unsigned>(value % 100));
 }
 
-constexpr auto write4(auto buf, std::integral auto value) {
-  *buf = static_cast<char>('0' + (value / 1000));
-  *++buf = static_cast<char>('0' + ((value / 100) % 10));
-  *++buf = static_cast<char>('0' + ((value / 10) % 10));
-  *++buf = static_cast<char>('0' + (value % 10));
-  return ++buf;
+// Write a valid status code (100-599) into buf, which must have room for at least 3 bytes. Returns the pointer
+// immediately after the last written byte.
+constexpr auto writeStatusCode(char* buf, http::StatusCode status) noexcept {
+  buf[0] = static_cast<char>('1' + ((status - 100) / 100));
+  return write2(buf + 1, static_cast<uint16_t>(status % 100));
+}
+
+constexpr auto write3(auto buf, std::integral auto value) noexcept {
+  const auto lhs = value / 100;
+  const auto rhs = value - (lhs * 100);
+
+  *buf++ = static_cast<char>('0' + lhs);
+  return write2(buf, rhs);
 }
 
 // Copy exactly 3 chars from a string_view known to have size >= 3.

--- a/aeronet/tech/include/aeronet/timestring.hpp
+++ b/aeronet/tech/include/aeronet/timestring.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstring>
 #include <string_view>
 
 #include "aeronet/simple-charconv.hpp"
@@ -84,35 +85,50 @@ inline SysTimePoint StringToTimeISO8601UTC(std::string_view timeStr) {
 /// WWW, DD Mon YYYY HH:MM:SS GMT
 /// Returns pointer past last written char.
 constexpr auto TimeToStringRFC7231(SysTimePoint tp, auto out) {
-  using namespace std::chrono;
+  // Fixed-width tables: no pointer-array indirection, just base + index*3.
+  static constexpr char kWeekdays[][3] = {
+      {'S', 'u', 'n'}, {'M', 'o', 'n'}, {'T', 'u', 'e'}, {'W', 'e', 'd'},
+      {'T', 'h', 'u'}, {'F', 'r', 'i'}, {'S', 'a', 't'},
+  };
 
-  static constexpr const char* const WEEKDAYS[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-  static constexpr const char* const MONTHS[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                                 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+  static constexpr char kMonths[][3] = {
+      {'J', 'a', 'n'}, {'F', 'e', 'b'}, {'M', 'a', 'r'}, {'A', 'p', 'r'}, {'M', 'a', 'y'}, {'J', 'u', 'n'},
+      {'J', 'u', 'l'}, {'A', 'u', 'g'}, {'S', 'e', 'p'}, {'O', 'c', 't'}, {'N', 'o', 'v'}, {'D', 'e', 'c'},
+  };
+
+  static constexpr char kSkeleton[] = {
+      '?', '?', '?', ',', ' ', '?', '?', ' ', '?', '?', '?', ' ', '?', '?', '?',
+      '?', ' ', '?', '?', ':', '?', '?', ':', '?', '?', ' ', 'G', 'M', 'T',
+  };
+
+  using namespace std::chrono;
 
   const sys_seconds secTp = time_point_cast<seconds>(tp);
   const auto day_point = floor<days>(secTp);
   const year_month_day ymd{day_point};
   const weekday wd{day_point};
-  const hh_mm_ss hms{secTp - day_point};
 
-  out = copy3(out, WEEKDAYS[wd.c_encoding()]);
-  *out = ',';
-  *++out = ' ';
-  out = write2(++out, static_cast<unsigned>(ymd.day()));
-  *out = ' ';
-  out = copy3(++out, MONTHS[static_cast<unsigned>(ymd.month()) - 1]);
-  *out = ' ';
-  out = write4(++out, static_cast<int>(ymd.year()));
-  *out = ' ';
-  out = write2(++out, hms.hours().count());
-  *out = ':';
-  out = write2(++out, hms.minutes().count());
-  *out = ':';
-  out = write2(++out, hms.seconds().count());
-  *out = ' ';
+  // Seconds since midnight, in [0, 86400). Two divisions instead of three:
+  // m and s are both derived from the remainder after removing hours.
+  const unsigned tod = static_cast<unsigned>((secTp - day_point).count());
+  const unsigned hour = tod / 3600;
+  const unsigned rem = tod - (hour * 3600);
+  const unsigned min = rem / 60;
+  const unsigned sec = rem - (min * 60);
 
-  return copy3(++out, "GMT");
+  std::memcpy(out, kSkeleton, sizeof(kSkeleton));
+
+  std::memcpy(out, kWeekdays[wd.c_encoding()], sizeof(kWeekdays[0]));
+  write2(out + 5, static_cast<unsigned>(ymd.day()));
+
+  std::memcpy(out + 8, kMonths[static_cast<unsigned>(ymd.month()) - 1], sizeof(kMonths[0]));
+
+  write4(out + 12, static_cast<int>(ymd.year()));
+  write2(out + 17, hour);
+  write2(out + 20, min);
+  write2(out + 23, sec);
+
+  return out + sizeof(kSkeleton);
 }
 
 inline constexpr SysTimePoint kInvalidTimePoint = SysTimePoint::max();

--- a/aeronet/tech/src/https-redirect.cpp
+++ b/aeronet/tech/src/https-redirect.cpp
@@ -71,11 +71,11 @@ bool AppendHttpsAuthority(RawChars& out, std::string_view hostHeader, uint16_t t
   }
 
   const bool addPort = targetPort != kStandardHttpsPort;
-  const auto hostNbDigits = addPort ? nchars(targetPort) : 0;
+  const std::uint8_t hostNbChars = addPort ? nchars(targetPort) : 0;
 
   std::size_t requiredCapacity = kHttpsScheme.size() + host.size();
   if (addPort) {
-    requiredCapacity += 1 + static_cast<std::size_t>(hostNbDigits);  // ':' + port digits
+    requiredCapacity += 1U + hostNbChars;  // ':' + port digits
   }
 
   out.reserve(requiredCapacity);

--- a/aeronet/tech/test/simple-charconv_test.cpp
+++ b/aeronet/tech/test/simple-charconv_test.cpp
@@ -33,6 +33,21 @@ TEST(SimpleCharConv, Write3) {
   EXPECT_EQ(std::string_view(buf, sizeof(buf)), "187");
 }
 
+TEST(SimpleCharConv, WriteStatusCode) {
+  char buf[3];
+  auto ptr = writeStatusCode(buf, http::StatusCodeOK);
+  ASSERT_EQ(ptr - buf, 3);
+  EXPECT_EQ(std::string_view(buf, sizeof(buf)), "200");
+
+  ptr = writeStatusCode(buf, http::StatusCodeNotFound);
+  ASSERT_EQ(ptr - buf, 3);
+  EXPECT_EQ(std::string_view(buf, sizeof(buf)), "404");
+
+  ptr = writeStatusCode(buf, http::StatusCodeInternalServerError);
+  ASSERT_EQ(ptr - buf, 3);
+  EXPECT_EQ(std::string_view(buf, sizeof(buf)), "500");
+}
+
 TEST(SimpleCharConv, Write4) {
   char buf[4];
   auto ptr = write4(buf, 7);


### PR DESCRIPTION
Quick benchmark results:

```
2026-07-20T23:41:56+02:00
Running ./a.out
Run on (20 X 434.178 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1280 KiB (x10)
  L3 Unified 24576 KiB (x1)
Load Average: 0.86, 0.89, 1.32
-------------------------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------
BM_TimeToStringRFC7231_Original        22.9 ns         22.9 ns     30525501 items_per_second=2.18469T/s
BM_TimeToStringRFC7231_Optimized       15.7 ns         15.7 ns     44532539 items_per_second=3.18268T/s
```

And for the writes alone:

```
2026-07-20T23:43:16+02:00
Running ./a.out
Run on (20 X 400 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1280 KiB (x10)
  L3 Unified 24576 KiB (x1)
Load Average: 0.66, 0.86, 1.28
-------------------------------------------------------------
Benchmark                   Time             CPU   Iterations
-------------------------------------------------------------
BM_write2_div           0.926 ns        0.926 ns    630706111
BM_write2_table         0.572 ns        0.572 ns   1771328841
BM_write3_div            2.45 ns         2.45 ns    285364628
BM_writeStatusCode       2.29 ns         2.29 ns    304049519
```